### PR TITLE
correct empty test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -354,6 +354,14 @@ jobs:
             tags: mutect1
           - profile: "conda"
             tags: ppflagfixer
+          - profile: "conda"
+            tags: pvmaf/tag
+          - profile: "conda"
+            tags: pvmaf/concat
+          - profile: "conda"
+            tags: genotypevariants/all
+          - profile: "conda"
+            tags: subworkflows/traceback
     env:
       NXF_ANSI_LOG: false
       SENTIEON_LICENSE_BASE64: ${{ secrets.SENTIEON_LICENSE_BASE64 }}


### PR DESCRIPTION
Gitactions linting throws an error if empty pytest file isn't specified like this. 