### PR TITLE
Feature/netmhcpan optimize

### DIFF
--- a/modules/msk/netmhcpan/main.nf
+++ b/modules/msk/netmhcpan/main.nf
@@ -9,10 +9,11 @@ process NETMHCPAN {
 
     input:
     tuple val(meta),  path(inputMaf), path(hlaFile)
+    val inputType
 
     output:
-    tuple val(meta), path("*.MUT.xls"),path("*.WT.xls"), emit: xls
-    tuple val(meta), path("*.MUT.netmhcpan.output"), path("*.WT.netmhcpan.output"), emit: netmhcpanoutput
+    tuple val(meta), path("*.xls"), emit: xls
+    tuple val(meta), path("*.netmhcpan.output"), emit: netmhcpanoutput
     tuple val(meta), path("*_out/*.mutated_sequences.fa"), path("*_out/*.WT_sequences.fa"), emit: fastaSequences
     path "versions.yml"           , emit: versions
 
@@ -25,6 +26,7 @@ process NETMHCPAN {
     def netMHCpan_version = '4.1'
     def in_CDS_file = task.ext.in_CDS_file ?: "/usr/local/bin/Homo_sapiens.GRCh37.75.cds.all.fa.gz"
     def in_CDNA_file = task.ext.in_CDNA_file ?:"/usr/local/bin/Homo_sapiens.GRCh37.75.cdna.all.fa.gz"
+
     """
     mkdir ${prefix}_out
     python3 /usr/local/bin/generateMutFasta.py --sample_id ${prefix} \
@@ -58,9 +60,23 @@ process NETMHCPAN {
     output_hla="\${output_hla:1}"
 
     echo \$output_hla
-    /usr/local/bin/netMHCpan-4.1/netMHCpan -s 1 -BA 1 -f ./${prefix}_out/${prefix}.mutated_sequences.fa -a \$output_hla -l 9,10 -inptype 0 -xls -xlsfile ${prefix}.MUT.xls > ${prefix}.MUT.netmhcpan.output
 
-    /usr/local/bin/netMHCpan-4.1/netMHCpan -s 1 -BA 1 -f ./${prefix}_out/${prefix}.WT_sequences.fa -a \$output_hla -l 9,10 -inptype 0 -xls -xlsfile ${prefix}.WT.xls > ${prefix}.WT.netmhcpan.output
+
+    if [ "$inputType" == "MUT" ]; then
+        # Execute MUT command
+        /usr/local/bin/netMHCpan-4.1/netMHCpan -s 1 -BA 1 -f ./${prefix}_out/${prefix}.mutated_sequences.fa -a \$output_hla -l 9,10 -inptype 0 -xls -xlsfile ${prefix}.MUT.xls > ${prefix}.MUT.netmhcpan.output
+    elif [ "$inputType" == "WT" ]; then
+        # Execute WT 
+        /usr/local/bin/netMHCpan-4.1/netMHCpan -s 1 -BA 1 -f ./${prefix}_out/${prefix}.WT_sequences.fa -a \$output_hla -l 9,10 -inptype 0 -xls -xlsfile ${prefix}.WT.xls > ${prefix}.WT.netmhcpan.output
+    else
+        # By default do both.
+        /usr/local/bin/netMHCpan-4.1/netMHCpan -s 1 -BA 1 -f ./${prefix}_out/${prefix}.mutated_sequences.fa -a \$output_hla -l 9,10 -inptype 0 -xls -xlsfile ${prefix}.MUT.xls > ${prefix}.MUT.netmhcpan.output
+        /usr/local/bin/netMHCpan-4.1/netMHCpan -s 1 -BA 1 -f ./${prefix}_out/${prefix}.WT_sequences.fa -a \$output_hla -l 9,10 -inptype 0 -xls -xlsfile ${prefix}.WT.xls > ${prefix}.WT.netmhcpan.output
+
+    fi
+
+
+
 
 
     cat <<-END_VERSIONS > versions.yml
@@ -75,9 +91,7 @@ process NETMHCPAN {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.MUT.netmhcpan.output
-    touch ${prefix}.WT.netmhcpan.output
     touch ${prefix}.MUT.xls
-    touch ${prefix}.WT.xls
     mkdir ${prefix}_out
     touch ${prefix}_out/${prefix}.mutated_sequences.fa
     touch ${prefix}_out/${prefix}.WT_sequences.fa

--- a/modules/msk/netmhcpan/meta.yml
+++ b/modules/msk/netmhcpan/meta.yml
@@ -31,6 +31,11 @@ input:
       description: HLA tsv outputtted by Polysolver
       pattern: "winners.{tsv}"
 
+  - inputType:
+      type: val
+      description: Allows netmhcpan to run in parallel. Should be 'MUT' or 'WT', it will kick off two jobs. make a Channel.Of('MUT','WT') outside the module as an input. Running them in series is kicked off by putting in anything other than MUT or WT.
+      pattern: "*"
+
 output:
   #Only when we have meta
   - meta:

--- a/modules/msk/netmhcpan/meta.yml
+++ b/modules/msk/netmhcpan/meta.yml
@@ -32,7 +32,7 @@ input:
       pattern: "winners.{tsv}"
 
   - inputType:
-      type: val
+      type: string
       description: Allows netmhcpan to run in parallel. Should be 'MUT' or 'WT', it will kick off two jobs. make a Channel.Of('MUT','WT') outside the module as an input. Running them in series is kicked off by putting in anything other than MUT or WT.
       pattern: "*"
 

--- a/modules/msk/netmhcpan/tests/main.nf.test
+++ b/modules/msk/netmhcpan/tests/main.nf.test
@@ -18,7 +18,7 @@ nextflow_process {
                     file(file(params.test_data_mskcc['neoantigen']['temp_test_short_maf']), checkIfExists: true),
                     file(file(params.test_data_mskcc['neoantigen']['winners_hla_txt']), checkIfExists: true)
                     ]
-
+                input[1] = 'MUT'
                 """
             }
         }
@@ -30,9 +30,7 @@ nextflow_process {
                     process.out.versions,
                     process.out.fastaSequences,
                     file(process.out.xls[0][1]).name,
-                    file(process.out.xls[0][2]).name,
-                    file(process.out.netmhcpanoutput[0][1]).name,
-                    file(process.out.netmhcpanoutput[0][2]).name
+                    file(process.out.netmhcpanoutput[0][1]).name
                     ).match()
                 }
             )
@@ -53,6 +51,8 @@ nextflow_process {
                     file('winners_hla_txt')
                     ]
 
+                input[1] = 'MUT'
+
                 """
             }
         }
@@ -64,9 +64,7 @@ nextflow_process {
                     process.out.versions,
                     process.out.fastaSequences,
                     file(process.out.xls[0][1]).name,
-                    file(process.out.xls[0][2]).name,
-                    file(process.out.netmhcpanoutput[0][1]).name,
-                    file(process.out.netmhcpanoutput[0][2]).name
+                    file(process.out.netmhcpanoutput[0][1]).name
                     ).match()
                 }
             )

--- a/modules/msk/netmhcpan/tests/main.nf.test.snap
+++ b/modules/msk/netmhcpan/tests/main.nf.test.snap
@@ -15,11 +15,13 @@
                 ]
             ],
             "test.MUT.xls",
-            "test.WT.xls",
-            "test.MUT.netmhcpan.output",
-            "test.WT.netmhcpan.output"
+            "test.MUT.netmhcpan.output"
         ],
-        "timestamp": "2024-03-27T16:03:49.449294"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.0"
+        },
+        "timestamp": "2024-04-04T12:07:50.109319"
     },
     "netmhcpan - xls,output,fa - stub": {
         "content": [
@@ -37,10 +39,12 @@
                 ]
             ],
             "test.MUT.xls",
-            "test.WT.xls",
-            "test.MUT.netmhcpan.output",
-            "test.WT.netmhcpan.output"
+            "test.MUT.netmhcpan.output"
         ],
-        "timestamp": "2024-03-27T16:05:06.65743"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.0"
+        },
+        "timestamp": "2024-04-04T12:26:17.357554"
     }
 }


### PR DESCRIPTION
Previously netmhcpan was run on both MUT and wild type in series.  Now with the addition of a channel for inputType which should be 'MUT' or 'WT', it will kick off two jobs.  Just make a Channel.Of('MUT','WT') outside the module as an input and it should work.  The original function of running them in series is kicked off by putting in anything other than MUT or WT.