### PR TITLE
Hotfix/neoantigeninputs version

### DIFF
--- a/modules/msk/neoantigeninput/eval_phyloWGS.py
+++ b/modules/msk/neoantigeninput/eval_phyloWGS.py
@@ -151,7 +151,7 @@ def main(args):
         outer_dict['sample_trees'].append(inner_sample_tree_dict)
 
 
-    outer_dict['Mutations'] = mutation_list
+    outer_dict['mutations'] = mutation_list
     
     #TODO format HLA_gene input data, depending on format inputted.  They should look like this A*02:01
     #this will be setup for polysolver winners output

--- a/modules/msk/neoantigeninput/main.nf
+++ b/modules/msk/neoantigeninput/main.nf
@@ -37,12 +37,13 @@ process NEOANTIGENINPUT {
         python3 /usr/bin/eval_phyloWGS.py --maf_file ${inputMaf} \
         --summary_file ${id}.summ.json \
         --mutation_file ${id}.mut.json \
-        --tree_directory \$tree_folder_name \
+        --tree_directory \$tree_folder_name/\$tree_folder_name \
         --id ${id} --patient_id ${patientid} \
         --cohort ${cohort} --HLA_genes ${hlaFile} \
         --netMHCpan_MUT_input ${mutNetMHCpan} \
         --netMHCpan_WT_input ${wtNetMHCpan}
         ${args}
+        
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/modules/msk/neoantigeninput/main.nf
+++ b/modules/msk/neoantigeninput/main.nf
@@ -2,8 +2,8 @@ process NEOANTIGENINPUT {
     tag "$meta.id"
     label 'process_single'
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://mskcc/neoantigeninputs:1.0.3':
-        'docker.io/mskcc/neoantigeninputs:1.0.3' }"
+        'docker://mskcc/neoantigeninputs:1.0.4':
+        'docker.io/mskcc/neoantigeninputs:1.0.4' }"
 
     input:
     tuple val(meta),  path(inputMaf),      path(hlaFile)
@@ -26,7 +26,8 @@ process NEOANTIGENINPUT {
     
     """
         tree_folder_name=\$(basename -s .zip "${phyloWGSfolder}")
-        unzip ${phyloWGSfolder}
+        mkdir \$tree_folder_name
+        unzip ${phyloWGSfolder} -d \$tree_folder_name
 
         gzip -d -c ${phyloWGSsumm} > ${id}.summ.json
         gzip -d -c ${phyloWGSmut} > ${id}.mut.json

--- a/modules/msk/neoantigeninput/tests/main.nf.test.snap
+++ b/modules/msk/neoantigeninput/tests/main.nf.test.snap
@@ -48,11 +48,7 @@
                 ]
             }
         ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.0"
-        },
-        "timestamp": "2024-04-04T17:05:38.949118"
+        "timestamp": "2024-04-05T18:16:07.635268"
     },
     "neoantigeninput - json,tsv": {
         "content": [
@@ -63,7 +59,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_patient_test_.json:md5,35faffcc545dd95218cd8f8d55768c61"
+                        "test_patient_test_.json:md5,4c08046a6f5826a3d51c221c6eef6348"
                     ]
                 ],
                 "1": [
@@ -85,7 +81,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_patient_test_.json:md5,35faffcc545dd95218cd8f8d55768c61"
+                        "test_patient_test_.json:md5,4c08046a6f5826a3d51c221c6eef6348"
                     ]
                 ],
                 "netMHCpanreformatted": [
@@ -103,10 +99,6 @@
                 ]
             }
         ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.0"
-        },
-        "timestamp": "2024-04-04T17:05:32.699247"
+        "timestamp": "2024-04-05T18:15:58.939665"
     }
 }


### PR DESCRIPTION
Quick hotfix for neoantigeninputs.  
Fixes a small bug in the python script that only appears when chained into Neoantigenediting subworkflow. 

Also made unzip behavior more consistent.  

PR checklist
 This comment contains a description of changes (with reason).

- [x]  If you've fixed a bug or added code that should be tested, add tests!
- [x]  If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x]  If necessary, include test data in your PR.
- [x]  Remove all TODO statements.
- [x]  Emit the versions.yml file.
- [x]  Follow the naming conventions.
- [x]  Follow the parameters requirements.
- [x]  Follow the input/output options guidelines.
- [x]  Add a resource label
- [ ]  Use BioConda and BioContainers if possible to fulfil software requirements.
- [x]  Ensure code lints (using prettier)

Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:

- [x]  nf-test test --profile=docker --tag
- [x]  nf-test test --profile=singularity --tag
- [x]  nf-test test --profile=conda --tag (not applicable; conda nf-test is disabled)