### PR TITLE
Bugfix/neoantigen input indel fixes

### DIFF
--- a/modules/msk/neoantigenutils/neoantigeninput/resources/usr/bin/generate_input.py
+++ b/modules/msk/neoantigenutils/neoantigeninput/resources/usr/bin/generate_input.py
@@ -457,7 +457,7 @@ def main(args):
         row_MUT_identity = trim_id(row_mut["Identity"])
         IDsplit = row_MUT_identity.split("_")
         SV = False
-        if row_mut["affinity"] < args.kD_cutoff:
+        if row_mut["affinity"] < float(args.kD_cutoff):
             peplen = len(row_mut["peptide"])
             matchfound = False
             if IDsplit[1][0] == "S" and IDsplit[1][1] != "p":

--- a/modules/msk/neoantigenutils/neoantigeninput/resources/usr/bin/generate_input.py
+++ b/modules/msk/neoantigenutils/neoantigeninput/resources/usr/bin/generate_input.py
@@ -551,7 +551,7 @@ def main(args):
                         best_pepmatch[-1] != row_mut["peptide"][-1]
                         and best_pepmatch2[-1] == row_mut["peptide"][-1]
                     ):
-                        # We should preferentially match the first AA if we can.  I have found that the pairwise alignment isnt always the best at this.
+                        # We should preferentially match the first AA if we can.  Sometimes the pairwise alignment isnt the best at this so we do a little check here.
                         # It will also do this when the last AA of the best match doesnt match but the last A of the second best match does
                         best_pepmatch = best_pepmatch2
 

--- a/modules/msk/neoantigenutils/neoantigeninput/resources/usr/bin/generate_input.py
+++ b/modules/msk/neoantigenutils/neoantigeninput/resources/usr/bin/generate_input.py
@@ -340,7 +340,7 @@ def main(args):
     WTdict = {}
     SVWTdict = {}
     for index_WT, row_WT in neoantigen_WT_in.iterrows():
-        noposID = ""
+        no_positon_ID = ""
         id = ""
         wtsvid = ""
         row_WT_identity = trim_id(row_WT["Identity"])
@@ -358,7 +358,7 @@ def main(args):
                 + "_"
                 + str(row_WT["pos"])
             )
-            noposID = (
+            no_positon_ID = (
                 IDsplit[0]
                 + "_"
                 + IDsplit[1][0:7]
@@ -372,8 +372,8 @@ def main(args):
                 "peptide": row_WT["peptide"],
             }
             id = wtsvid
-            if noposID not in WTdict:
-                WTdict[noposID] = {
+            if no_positon_ID not in WTdict:
+                WTdict[no_positon_ID] = {
                     "peptides": {
                         row_WT["peptide"]: id
                     },  # This is a dict so we can match the peptide with the actual ID later
@@ -381,7 +381,7 @@ def main(args):
                 }
 
             else:
-                WTdict[noposID]["peptides"][row_WT["peptide"]] = id
+                WTdict[no_positon_ID]["peptides"][row_WT["peptide"]] = id
 
         else:
             id = (
@@ -394,7 +394,7 @@ def main(args):
                 + str(row_WT["pos"])
             )
 
-            noposID = (
+            no_positon_ID = (
                 row_WT_identity[:-2]
                 + "_"
                 + str(len(row_WT["peptide"]))
@@ -404,8 +404,8 @@ def main(args):
             WTdict[id] = {"affinity": row_WT["affinity"], "peptide": row_WT["peptide"]}
 
             # This is used as last resort for the matching.  We will preferentially find the peptide matching in length as well as POS. Worst case we will default to the WT pos 0
-            if noposID not in WTdict:
-                WTdict[noposID] = {
+            if no_positon_ID not in WTdict:
+                WTdict[no_positon_ID] = {
                     "peptides": {
                         row_WT["peptide"]: id
                     },  # This is a dict so we can match the peptide with the ID later
@@ -413,7 +413,7 @@ def main(args):
                 }
 
             else:
-                WTdict[noposID]["peptides"][row_WT["peptide"]] = id
+                WTdict[no_positon_ID]["peptides"][row_WT["peptide"]] = id
 
     def find_most_similar_string(target, strings):
         max_score = -1
@@ -476,7 +476,7 @@ def main(args):
                     + "_"
                     + str(row_mut["pos"])
                 )
-                noposID = (
+                no_positon_ID = (
                     IDsplit[0]
                     + "_"
                     + IDsplit[1][0:8]
@@ -533,7 +533,7 @@ def main(args):
                         first_AA_same_score,
                         match_score,
                     ) = find_most_similar_string(
-                        row_mut["peptide"], list(WTdict[noposID]["peptides"].keys())
+                        row_mut["peptide"], list(WTdict[no_positon_ID]["peptides"].keys())
                     )
                     if (
                         best_pepmatch == row_mut["peptide"]
@@ -554,7 +554,7 @@ def main(args):
                         # It will also do this when the last AA of the best match doesnt match but the last A of the second best match does
                         best_pepmatch = best_pepmatch2
 
-                    WTid = WTdict[noposID]["peptides"][best_pepmatch]
+                    WTid = WTdict[no_positon_ID]["peptides"][best_pepmatch]
                     matchfound = True
 
             if matchfound == True and best_pepmatch != row_mut["peptide"]:

--- a/modules/msk/neoantigenutils/neoantigeninput/resources/usr/bin/generate_input.py
+++ b/modules/msk/neoantigenutils/neoantigeninput/resources/usr/bin/generate_input.py
@@ -460,6 +460,7 @@ def main(args):
         if row_mut["affinity"] < float(args.kD_cutoff):
             peplen = len(row_mut["peptide"])
             matchfound = False
+            frameshift= False
             if IDsplit[1][0] == "S" and IDsplit[1][1] != "p":
                 # If it is a silent mutation.  Silent mutations can either be S or SY. These include intron mutations.  Splices can be Sp
                 continue
@@ -519,12 +520,12 @@ def main(args):
                     #This block takes care of Missense mutations caused by polymorphisims
                     matchfound = True
                     best_pepmatch = WTdict[WTid]["peptide"]
-                    frameshift = False
+                    
                 else:
                     # Here we take care of INDELS and eveyrhting else
 
                     if ("-" in IDsplit[1] or "+" in IDsplit[1]):
-                        frameshift = False
+                        frameshift = True
 
                     (
                         best_pepmatch,

--- a/modules/msk/neoantigenutils/neoantigeninput/resources/usr/bin/generate_input.py
+++ b/modules/msk/neoantigenutils/neoantigeninput/resources/usr/bin/generate_input.py
@@ -8,7 +8,7 @@ from Bio import pairwise2
 from Bio.pairwise2 import format_alignment
 import numpy as np
 
-VERSION = 1.8
+VERSION = 1.9
 
 
 def main(args):
@@ -522,7 +522,7 @@ def main(args):
                     best_pepmatch = WTdict[WTid]["peptide"]
                     
                 else:
-                    # Here we take care of INDELS and eveyrhting else
+                    # Here we take care of INDELS and everything else
 
                     if ("-" in IDsplit[1] or "+" in IDsplit[1]):
                         frameshift = True

--- a/modules/msk/neoantigenutils/neoantigeninput/tests/main.nf.test.snap
+++ b/modules/msk/neoantigenutils/neoantigeninput/tests/main.nf.test.snap
@@ -29,10 +29,10 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.04.4"
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
         },
-        "timestamp": "2024-11-29T15:37:10.311539"
+        "timestamp": "2025-02-05T14:07:49.603422669"
     },
     "neoantigenutils_neoantigeninput - bedpe,json,tsv": {
         "content": [
@@ -43,7 +43,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_patient_test_.json:md5,401207e1ed3fb2708291a8eeff5efcd7"
+                        "test_patient_test_.json:md5,7fdb25ccc6ed41f53aa03507d982ea05"
                     ]
                 ],
                 "1": [
@@ -55,7 +55,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_patient_test_.json:md5,401207e1ed3fb2708291a8eeff5efcd7"
+                        "test_patient_test_.json:md5,7fdb25ccc6ed41f53aa03507d982ea05"
                     ]
                 ],
                 "versions": [
@@ -64,10 +64,10 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.04.4"
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
         },
-        "timestamp": "2024-11-29T15:36:59.107384"
+        "timestamp": "2025-02-05T14:07:27.768140272"
     },
     "neoantigenutils_neoantigeninput - json,tsv": {
         "content": [
@@ -78,7 +78,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_patient_test_.json:md5,f9db7a487cbd4aad167819d885a9a9e3"
+                        "test_patient_test_.json:md5,a81ee3977fa393850e0b7b36321d1143"
                     ]
                 ],
                 "1": [
@@ -90,7 +90,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_patient_test_.json:md5,f9db7a487cbd4aad167819d885a9a9e3"
+                        "test_patient_test_.json:md5,a81ee3977fa393850e0b7b36321d1143"
                     ]
                 ],
                 "versions": [
@@ -99,9 +99,9 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.04.4"
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
         },
-        "timestamp": "2024-11-29T15:37:06.847468"
+        "timestamp": "2025-02-05T14:07:40.874130873"
     }
 }

--- a/modules/msk/neoantigenutils/neoantigeninput/tests/main.nf.test.snap
+++ b/modules/msk/neoantigenutils/neoantigeninput/tests/main.nf.test.snap
@@ -32,7 +32,7 @@
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2025-02-05T14:07:49.603422669"
+        "timestamp": "2025-02-05T14:38:57.427385617"
     },
     "neoantigenutils_neoantigeninput - bedpe,json,tsv": {
         "content": [
@@ -67,7 +67,7 @@
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2025-02-05T14:07:27.768140272"
+        "timestamp": "2025-02-05T14:38:35.2939696"
     },
     "neoantigenutils_neoantigeninput - json,tsv": {
         "content": [
@@ -102,6 +102,6 @@
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2025-02-05T14:07:40.874130873"
+        "timestamp": "2025-02-05T14:38:48.778108545"
     }
 }


### PR DESCRIPTION
Fixes a bug pertaining to indel input generation, changed some variable names to make things clearer, and also adds kd_cutoff as an arg that is passable using ${args}

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] Check to see if a [nf-core module, or subworkflow](https://github.com/nf-core/modules) is available and usable for your pipeline.
- [x] Feature branch is named `feature/<module_name>` for modules, or `feature/<subworkflow_name>` for subworkflows. For modules, if there is a subcommand use: `feature/<module_name>/<module_subcommand>`.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://mskcc-omics-workflows.gitbook.io/omics-wf/GMaCKqX0TmAhUOoZmuc6).
- [x] Use [nf-core data](https://github.com/nf-core/test-datasets) if possible for nf-tests. If not, use or add test data to [mskcc-omics-workflows/test-datasets](https://github.com/mskcc-omics-workflows/test-datasets), following the repository guidelines, for nf-tests. Finally, if neither option is feasible, only add a stub nf-test.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`.
- [ ] Use Jfrog if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <module_branch> test <MODULE> --profile docker`
    - [ ] `nf-core modules --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <module_branch> test <MODULE> --profile singularity`
    - [ ] `nf-core modules --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <module_branch> test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <subworkflow_branch> test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <subworkflow_branch> test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <subworkflow_branch> test <SUBWORKFLOW> --profile conda`
