### PR TITLE
Guard compute_effective_sample_size against empty sample_trees

### DIFF
--- a/modules/msk/neoantigenediting/computefitness/resources/usr/bin/compute_fitness.py
+++ b/modules/msk/neoantigenediting/computefitness/resources/usr/bin/compute_fitness.py
@@ -159,9 +159,12 @@ def compute_effective_sample_size(sample_json):
         for clone_muts, X in zip(clone_muts_list, freqs):
             for mid in clone_muts:
                 mut_freqs[mid].append(X)
-    avev = np.mean(
-        [np.var(mut_freqs[mid]) if mut_freqs[mid] else 0 for mid in mut_freqs]
-    )
+    variances = [np.var(mut_freqs[mid]) if mut_freqs[mid] else 0 for mid in mut_freqs]
+    if not variances:
+        return 0
+    avev = np.mean(variances)
+    if avev == 0 or np.isnan(avev):
+        return 0
     n = 1 / avev
     return n
 


### PR DESCRIPTION
## Summary

Add guards to `compute_effective_sample_size()` in `compute_fitness.py` to handle cases where `sample_trees` is empty.

## Problem

When `sample_trees` is empty (e.g., when PhyloWGS is skipped in the NeoAntigen-Pipeline), the mutation frequency lists remain empty. This caused:
- `np.mean([0, 0, ...])` to return `0`
- `1 / 0` to raise `ZeroDivisionError`

## Solution

Added guards to return `0` for `Effective_N` when:
- No variances can be computed (empty mutations list)
- Average variance is `0` or `NaN` (empty sample_trees)

## Changes

```python
# Before
avev = np.mean(
    [np.var(mut_freqs[mid]) if mut_freqs[mid] else 0 for mid in mut_freqs]
)
n = 1 / avev
return n

# After
variances = [np.var(mut_freqs[mid]) if mut_freqs[mid] else 0 for mid in mut_freqs]
if not variances:
    return 0
avev = np.mean(variances)
if avev == 0 or np.isnan(avev):
    return 0
n = 1 / avev
return n


## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] Check to see if a [nf-core module, or subworkflow](https://github.com/nf-core/modules) is available and usable for your pipeline.
- [ ] Feature branch is named `feature/<module_name>` for modules, or `feature/<subworkflow_name>` for subworkflows. For modules, if there is a subcommand use: `feature/<module_name>/<module_subcommand>`.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://mskcc-omics-workflows.gitbook.io/omics-wf/GMaCKqX0TmAhUOoZmuc6).
- [ ] Use [nf-core data](https://github.com/nf-core/test-datasets) if possible for nf-tests. If not, use or add test data to [mskcc-omics-workflows/test-datasets](https://github.com/mskcc-omics-workflows/test-datasets), following the repository guidelines, for nf-tests. Finally, if neither option is feasible, only add a stub nf-test.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`.
- [ ] Use Jfrog if possible to fulfill software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <module_branch> test <MODULE> --profile docker`
    - [ ] `nf-core modules --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <module_branch> test <MODULE> --profile singularity`
    - [ ] `nf-core modules --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <module_branch> test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <subworkflow_branch> test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <subworkflow_branch> test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <subworkflow_branch> test <SUBWORKFLOW> --profile conda`
