### PR TITLE
Nextflow 26.x compat and tabs→spaces in generatemutfasta

### DIFF
--- a/modules/msk/generatemutfasta/main.nf
+++ b/modules/msk/generatemutfasta/main.nf
@@ -28,9 +28,9 @@ process GENERATEMUTFASTA {
     tar -xzf ${mutalyzer_cache} -C \$(pwd)/mutalyzer_cache
 
     cat <<-END_MUTALYZER_CONFIG > \$(pwd)/config.txt
-	MUTALYZER_CACHE_DIR = \$(pwd)/mutalyzer_cache/cache
-	MUTALYZER_FILE_CACHE_ADD = false
-	END_MUTALYZER_CONFIG
+    MUTALYZER_CACHE_DIR = \$(pwd)/mutalyzer_cache/cache
+    MUTALYZER_FILE_CACHE_ADD = false
+    END_MUTALYZER_CONFIG
 
     mkdir ${prefix}_out
 

--- a/modules/msk/generatemutfasta/main.nf
+++ b/modules/msk/generatemutfasta/main.nf
@@ -27,10 +27,8 @@ process GENERATEMUTFASTA {
 
     tar -xzf ${mutalyzer_cache} -C \$(pwd)/mutalyzer_cache
 
-    cat <<-END_MUTALYZER_CONFIG > \$(pwd)/config.txt
-    MUTALYZER_CACHE_DIR = \$(pwd)/mutalyzer_cache/cache
-    MUTALYZER_FILE_CACHE_ADD = false
-    END_MUTALYZER_CONFIG
+    echo MUTALYZER_CACHE_DIR = \$(pwd)/mutalyzer_cache/cache >> \$(pwd)/config.txt
+    echo MUTALYZER_FILE_CACHE_ADD = false >> \$(pwd)/config.txt
 
     mkdir ${prefix}_out
 

--- a/subworkflows/msk/generate_mutated_peptides/main.nf
+++ b/subworkflows/msk/generate_mutated_peptides/main.nf
@@ -74,17 +74,17 @@ workflow GENERATE_MUTATED_PEPTIDES {
 }
 
 def createNEOSVInput(sv_bedpe, hla_str) {
-        sv_bedpe_channel = sv_bedpe
+        def sv_bedpe_channel = sv_bedpe
             .map{
                 new Tuple(it[0],it)
                 }
 
-        hla_str_channel = hla_str
+        def hla_str_channel = hla_str
             .map{
                 new Tuple(it[0],it)
                 }
 
-        merged_sv_hla = sv_bedpe_channel
+        def merged_sv_hla = sv_bedpe_channel
             .join(hla_str_channel, by:0)
             .map{
                 new Tuple(it[1][0], it[1][1], it[2][1])

--- a/subworkflows/msk/netmhcstabandpan/main.nf
+++ b/subworkflows/msk/netmhcstabandpan/main.nf
@@ -48,27 +48,27 @@ workflow NETMHCSTABANDPAN {
 }
 
 def createNETMHCInput(fastas_and_hla, sv_fastas) {
-        fastas_and_hla_channel = fastas_and_hla
+        def fastas_and_hla_channel = fastas_and_hla
             .map{
                 new Tuple(it[0],it)
                 }
 
-        sv_fastas_channel = sv_fastas
+        def sv_fastas_channel = sv_fastas
             .map{
                 new Tuple(it[0],it)
                 }
 
-        merged_mut = fastas_and_hla_channel
+        def merged_mut = fastas_and_hla_channel
             .join(sv_fastas_channel, by:0)
             .map({
                 new Tuple(it[1][0], it[1][1], it[2][1], it[1][3], "MUT")
             })
 
-        merged_wt = fastas_and_hla_channel
+        def merged_wt = fastas_and_hla_channel
             .join(sv_fastas_channel, by:0)
             .map({
                 new Tuple(it[1][0], it[1][2], it[2][2], it[1][3], "WT")
             })
-        merged = merged_mut.mix(merged_wt)
+        def merged = merged_mut.mix(merged_wt)
         return merged
 }

--- a/subworkflows/msk/phylowgs/main.nf
+++ b/subworkflows/msk/phylowgs/main.nf
@@ -50,17 +50,17 @@ workflow PHYLOWGS {
 }
 
 def join_maf_with_cnv(maf,cnv) {
-        maf_channel = maf
+        def maf_channel = maf
             .map{
                 new Tuple(it[0].id,it)
                 }
-        cnv_channel = cnv
+        def cnv_channel = cnv
             .map{
                 new Tuple(it[0].id,it)
                 }
-        mergedWithKey = maf_channel
+        def mergedWithKey = maf_channel
             .join(cnv_channel)
-        merged = mergedWithKey
+        def merged = mergedWithKey
             .map{
                 new Tuple(it[1][0],it[1][1],it[2][1])
             }


### PR DESCRIPTION
### Fix A
- generatemutfasta tabs→spaces: Converted 3 lines (31-33) in modules/msk/generatemutfasta/main.nf from tab to 4-space indentation in the END_MUTALYZER_CONFIG heredoc. This fixes the YAML runtime error caused by stripIndent() + mixed tab/space indentation.

### Fix B 
- def keyword for Nextflow 26.x: Added def to 12 local variables across 3 subworkflow helper functions:
- generate_mutated_peptides/main.nf → createNEOSVInput() (3 vars)
- netmhcstabandpan/main.nf → createNETMHCInput() (5 vars)
- phylowgs/main.nf → join_maf_with_cnv() (4 vars)
This prepares us for nextflow v26 
  
## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] Check to see if a [nf-core module, or subworkflow](https://github.com/nf-core/modules) is available and usable for your pipeline.
- [x] Feature branch is named `feature/<module_name>` for modules, or `feature/<subworkflow_name>` for subworkflows. For modules, if there is a subcommand use: `feature/<module_name>/<module_subcommand>`.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://mskcc-omics-workflows.gitbook.io/omics-wf/GMaCKqX0TmAhUOoZmuc6).
- [ ] Use [nf-core data](https://github.com/nf-core/test-datasets) if possible for nf-tests. If not, use or add test data to [mskcc-omics-workflows/test-datasets](https://github.com/mskcc-omics-workflows/test-datasets), following the repository guidelines, for nf-tests. Finally, if neither option is feasible, only add a stub nf-test.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`.
- [ ] Use Jfrog if possible to fulfill software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <module_branch> test <MODULE> --profile docker`
    - [ ] `nf-core modules --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <module_branch> test <MODULE> --profile singularity`
    - [ ] `nf-core modules --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <module_branch> test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <subworkflow_branch> test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <subworkflow_branch> test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <subworkflow_branch> test <SUBWORKFLOW> --profile conda`
