### PR TITLE
Implement compression type validation for FASTA files

### DIFF
--- a/modules/msk/mutalyzer/retriever/main.nf
+++ b/modules/msk/mutalyzer/retriever/main.nf
@@ -20,11 +20,22 @@ process MUTALYZER_RETRIEVER {
     """
     if ! bgzip --reindex ${fasta} > /dev/null 2>&1
     then
-        # Re-compress fasta with bgzip
-
-        mv ${fasta} ${fasta.baseName}.tmp.gzip
-        gunzip -c ${fasta.baseName}.tmp.gzip | bgzip -c > ${fasta}
-        bgzip --reindex ${fasta}
+        # Determine compression type by magic bytes before attempting recompression
+        MAGIC=\$(xxd -l 2 -p ${fasta})
+        if [ "\$MAGIC" = "1f8b" ]; then
+            # Standard gzip — re-compress with bgzip
+            mv ${fasta} ${fasta.baseName}.tmp.gzip
+            gunzip -c ${fasta.baseName}.tmp.gzip | bgzip -c > ${fasta}
+            bgzip --reindex ${fasta}
+            rm ${fasta.baseName}.tmp.gzip
+        elif [ "\$MAGIC" = "425a" ]; then
+            echo "ERROR: ${fasta} is bzip2-compressed. Please provide a gzip or bgzip-compressed FASTA." >&2
+            exit 1
+        else
+            echo "ERROR: ${fasta} does not appear to be gzip-compressed or bgzip-indexed." >&2
+            echo "       Please provide a bgzip-compressed FASTA (e.g. bgzip genome.fa)." >&2
+            exit 1
+        fi
     fi
 
     # Build cache


### PR DESCRIPTION
Add magic byte check for compression type before re-compressing FASTA files.

<!--
# mskcc-omics-workflows/modules pull request

Many thanks for contributing to mskcc-omics-workflows/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the develop branch.

Learn more about contributing: [gitbook](https://mskcc-omics-workflows.gitbook.io/omics-wf/GMaCKqX0TmAhUOoZmuc6)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] Check to see if a [nf-core module, or subworkflow](https://github.com/nf-core/modules) is available and usable for your pipeline.
- [ ] Feature branch is named `feature/<module_name>` for modules, or `feature/<subworkflow_name>` for subworkflows. For modules, if there is a subcommand use: `feature/<module_name>/<module_subcommand>`.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://mskcc-omics-workflows.gitbook.io/omics-wf/GMaCKqX0TmAhUOoZmuc6).
- [ ] Use [nf-core data](https://github.com/nf-core/test-datasets) if possible for nf-tests. If not, use or add test data to [mskcc-omics-workflows/test-datasets](https://github.com/mskcc-omics-workflows/test-datasets), following the repository guidelines, for nf-tests. Finally, if neither option is feasible, only add a stub nf-test.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`.
- [ ] Use Jfrog if possible to fulfill software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <module_branch> test <MODULE> --profile docker`
    - [ ] `nf-core modules --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <module_branch> test <MODULE> --profile singularity`
    - [ ] `nf-core modules --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <module_branch> test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <subworkflow_branch> test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <subworkflow_branch> test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <subworkflow_branch> test <SUBWORKFLOW> --profile conda`
