### PR TITLE
Fix NETMHCSTABANDPAN to support samples without SV data

### DIFF
--- a/subworkflows/msk/netmhcstabandpan/main.nf
+++ b/subworkflows/msk/netmhcstabandpan/main.nf
@@ -58,16 +58,19 @@ def createNETMHCInput(fastas_and_hla, sv_fastas) {
                 [it[0],it]
                 }
 
+        // remainder: true keeps samples that have no SV data (sv_fastas is empty when no SVs provided)
         def merged_mut = fastas_and_hla_channel
-            .join(sv_fastas_channel, by:0)
+            .join(sv_fastas_channel, by:0, remainder: true)
             .map({
-                [it[1][0], it[1][1], it[2][1], it[1][3], "MUT"]
+                def sv = it[2] ?: [null, [], []]
+                [it[1][0], it[1][1], sv[1], it[1][3], "MUT"]
             })
 
         def merged_wt = fastas_and_hla_channel
-            .join(sv_fastas_channel, by:0)
+            .join(sv_fastas_channel, by:0, remainder: true)
             .map({
-                [it[1][0], it[1][2], it[2][2], it[1][3], "WT"]
+                def sv = it[2] ?: [null, [], []]
+                [it[1][0], it[1][2], sv[2], it[1][3], "WT"]
             })
         def merged = merged_mut.mix(merged_wt)
         return merged

--- a/subworkflows/msk/netmhcstabandpan/tests/main.nf.test
+++ b/subworkflows/msk/netmhcstabandpan/tests/main.nf.test
@@ -162,6 +162,43 @@ nextflow_workflow {
     }
 
 
+    test("netmhcstabandpan - empty SV channel - fa,hla_str - tsv - stub") {
+
+        // Regression test: when no SV files are provided, the upstream NEOSV process
+        // doesn't run, so the sv_fasta channel emits zero items. The createNETMHCInput
+        // helper must still emit MUT and WT tuples for each sample.
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = channel.value([
+                    [ id:'test', single_end:false ], // meta map
+                    file('MUT_sequence_fa', checkIfExists: false),
+                    file('WT_sequence_fa', checkIfExists: false),
+                    "HLA-A24:02,HLA-A24:02,HLA-B39:01,HLA-B39:01,HLA-C07:01,HLA-C06:02",
+                    ])
+
+                input[1] = channel.empty()
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(workflow.out.tsv[0][0],
+                                  file(workflow.out.tsv[0][1]).name,
+                                  workflow.out.tsv[1][0],
+                                  file(workflow.out.tsv[1][1]).name
+                                  ).match()
+                }
+            )
+        }
+    }
+
+
     test("netmhcstabandpan - fa,hla_str - tsv - stub") {
 
         options "-stub"

--- a/subworkflows/msk/netmhcstabandpan/tests/main.nf.test.snap
+++ b/subworkflows/msk/netmhcstabandpan/tests/main.nf.test.snap
@@ -212,5 +212,30 @@
             "nextflow": "25.10.2"
         },
         "timestamp": "2025-12-19T14:22:41.854041255"
+    },
+    "netmhcstabandpan - empty SV channel - fa,hla_str - tsv - stub": {
+        "content": [
+            {
+                "id": "test",
+                "single_end": false,
+                "typeMut": false,
+                "fromStab": false,
+                "typePan": true
+            },
+            "test.WT.PAN.tsv",
+            {
+                "id": "test",
+                "single_end": false,
+                "typeMut": false,
+                "fromStab": true,
+                "typePan": true
+            },
+            "test.WT.STAB.tsv"
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.2"
+        },
+        "timestamp": "2026-05-13T22:29:19.315483"
     }
 }


### PR DESCRIPTION
## Description

Fixes a silent failure in the `NETMHCSTABANDPAN` subworkflow when samples are run **without structural variants** — a common case in MSK pipelines where the samplesheet only carries MAF/HLA/CNV inputs.

### Root cause

`createNETMHCInput` joins `ch_fasta_and_hla` against `ch_sv_fasta` with an **inner** `.join(...)`. When no SV files are provided in the samplesheet, the upstream `NEOSV` process never runs, so the SV fasta channel emits **zero items**. The inner join therefore produces an empty channel, and `NETMHCSTABPAN` / `NETMHCPAN4` / `NEOANTIGENUTILS_FORMATNETMHCPAN` — and everything downstream of them in any pipeline using this subworkflow — silently get skipped.

Existing tests cover the case where the SV channel emits `[meta, [], []]` (empty file lists with a meta), but not the "no items at all" case, which is what real pipelines hit when SVs aren't part of the sample.

### Change

Switch the join to a left join with `remainder: true` and treat a missing SV side as `[null, [], []]`, so a MUT and WT tuple is still emitted per sample regardless of SV presence:

```groovy
def merged_mut = fastas_and_hla_channel
    .join(sv_fastas_channel, by:0, remainder: true)
    .map({
        def sv = it[2] ?: [null, [], []]
        [it[1][0], it[1][1], sv[1], it[1][3], "MUT"]
    })
```

### Tests

Adds `netmhcstabandpan - empty SV channel - fa,hla_str - tsv - stub`, which feeds `input[1] = channel.empty()` to lock in the SV-less code path.

All 7 tests pass locally (Nextflow 24.10.6, nf-test 0.9.5):

```
Test [f411820f] 'netmhcstabandpan - SV - fa,hla_str - tsv'                                 PASSED
Test [474d8bcb] 'netmhcstabandnetmhc3 - SV - fa,hla_str - tsv'                             PASSED
Test [f20bb7d2] 'netmhcstabandpan - fa,hla_str - tsv'                                      PASSED
Test [b2d766c9] 'netmhcstabandnetmhc3 - fa,hla_str - tsv'                                  PASSED
Test [958a9bbe] 'netmhcstabandpan - empty SV channel - fa,hla_str - tsv - stub'  (NEW)     PASSED
Test [d1dc7b0c] 'netmhcstabandpan - fa,hla_str - tsv - stub'                               PASSED
Test [1be0a66d] 'netmhcstabandnetmhc3 - fa,hla_str - tsv - stub'                           PASSED
```

The fix was also verified end-to-end by running the `mskcc/neoantigenpipeline` (`-profile test,docker`): before the fix the pipeline silently completed with 6 of 13 stages skipped after `GENERATEMUTFASTA`; after the fix all 31 processes run to completion (0 failures), producing the final TSV and annotated JSON outputs.

## PR Checklist

- [x] Description of changes with reasoning
- [x] No nf-core equivalent (MSK-specific netMHC stack)
- [x] Branch named `feature/netmhcstabandpan`
- [x] Tests added for new code (regression test for empty SV channel)
- [x] No external test data needed (stub-mode test)
- [x] No TODOs introduced
- [x] `versions.yml` emission untouched
- [x] Naming conventions followed
- [x] No resource label changes
- [x] No container changes
