### PR TITLE
Stream NETMHCSTABANDPAN per sample instead of waiting on full SV channel

### DIFF
--- a/subworkflows/msk/generate_mutated_peptides/main.nf
+++ b/subworkflows/msk/generate_mutated_peptides/main.nf
@@ -56,24 +56,29 @@ workflow GENERATE_MUTATED_PEPTIDES {
 
     ch_versions = ch_versions.mix(GENERATEMUTFASTA.out.versions)
 
-    ch_neosv_input = createNEOSVInput( ch_sv , NEOANTIGENUTILS_GENERATEHLASTRING.out.hlastring )
+    ch_neosv_branched = branchNEOSVInput( ch_sv , NEOANTIGENUTILS_GENERATEHLASTRING.out.hlastring )
 
-    NEOSV( ch_neosv_input, ch_gtf_and_cdna )
+    NEOSV( ch_neosv_branched.with_sv, ch_gtf_and_cdna )
 
     ch_versions = ch_versions.mix(NEOSV.out.versions)
+
+    // Pad SV outputs with empty placeholders for samples without SV input so that
+    // downstream per-sample joins never have to wait for the full channel to close.
+    ch_sv_mut_fasta = NEOSV.out.mutOut.mix( ch_neosv_branched.without_sv.map{ [it[0], []] } )
+    ch_sv_wt_fasta  = NEOSV.out.wtOut.mix( ch_neosv_branched.without_sv.map{ [it[0], []] } )
 
     emit:
 
     mut_fasta      = GENERATEMUTFASTA.out.mut_fasta                   // channel: [ val(meta), [ *.MUT_sequences.fa ] ]
     wt_fasta       = GENERATEMUTFASTA.out.wt_fasta                    // channel: [ val(meta), [ *.WT_sequences.fa ] ]
     mut_fasta_log  = GENERATEMUTFASTA.out.mut_fasta_log               // channel: [ val(meta), [ *_generate_mut_fasta.log ] ]
-    sv_mut_fasta   = NEOSV.out.mutOut                                 // channel: [ val(meta), [ *.SV.MUT.fa ] ]
-    sv_wt_fasta    = NEOSV.out.wtOut                                  // channel: [ val(meta), [ *.SV.WT.fa ] ]
+    sv_mut_fasta   = ch_sv_mut_fasta                                  // channel: [ val(meta), [ *.SV.MUT.fa ] | [] ]
+    sv_wt_fasta    = ch_sv_wt_fasta                                   // channel: [ val(meta), [ *.SV.WT.fa ]  | [] ]
     hla_string     = NEOANTIGENUTILS_GENERATEHLASTRING.out.hlastring  // channel: [ val(meta), [ hla_string ] ]
     versions       = ch_versions                                      // channel: [ versions.yml ]
 }
 
-def createNEOSVInput(sv_bedpe, hla_str) {
+def branchNEOSVInput(sv_bedpe, hla_str) {
         def sv_bedpe_channel = sv_bedpe
             .map{
                 [it[0],it]
@@ -89,6 +94,9 @@ def createNEOSVInput(sv_bedpe, hla_str) {
             .map{
                 [it[1][0], it[1][1], it[2][1]]
             }
-            .filter{ it[1] != null && it[2] != null }
+            .branch{
+                with_sv:    it[1] != null && it[2] != null
+                without_sv: true
+            }
         return merged_sv_hla
 }

--- a/subworkflows/msk/netmhcstabandpan/main.nf
+++ b/subworkflows/msk/netmhcstabandpan/main.nf
@@ -58,19 +58,19 @@ def createNETMHCInput(fastas_and_hla, sv_fastas) {
                 [it[0],it]
                 }
 
-        // remainder: true keeps samples that have no SV data (sv_fastas is empty when no SVs provided)
+        // Callers are expected to pre-pad sv_fastas with [meta, []] for samples without SV data,
+        // so this is a plain inner join — each sample emits as soon as its fastas are ready and
+        // we never have to wait for the SV channel to close.
         def merged_mut = fastas_and_hla_channel
-            .join(sv_fastas_channel, by:0, remainder: true)
+            .join(sv_fastas_channel, by:0)
             .map({
-                def sv = it[2] ?: [null, [], []]
-                [it[1][0], it[1][1], sv[1], it[1][3], "MUT"]
+                [it[1][0], it[1][1], it[2][1], it[1][3], "MUT"]
             })
 
         def merged_wt = fastas_and_hla_channel
-            .join(sv_fastas_channel, by:0, remainder: true)
+            .join(sv_fastas_channel, by:0)
             .map({
-                def sv = it[2] ?: [null, [], []]
-                [it[1][0], it[1][2], sv[2], it[1][3], "WT"]
+                [it[1][0], it[1][2], it[2][2], it[1][3], "WT"]
             })
         def merged = merged_mut.mix(merged_wt)
         return merged

--- a/subworkflows/msk/netmhcstabandpan/tests/main.nf.test
+++ b/subworkflows/msk/netmhcstabandpan/tests/main.nf.test
@@ -162,11 +162,12 @@ nextflow_workflow {
     }
 
 
-    test("netmhcstabandpan - empty SV channel - fa,hla_str - tsv - stub") {
+    test("netmhcstabandpan - padded empty SV placeholder - fa,hla_str - tsv - stub") {
 
-        // Regression test: when no SV files are provided, the upstream NEOSV process
-        // doesn't run, so the sv_fasta channel emits zero items. The createNETMHCInput
-        // helper must still emit MUT and WT tuples for each sample.
+        // Regression test for the per-sample streaming contract:
+        // when a sample has no SV data, callers (e.g. GENERATE_MUTATED_PEPTIDES)
+        // pad the SV channel with [meta, [], []] so every sample matches the
+        // inner join. The subworkflow must still emit per-sample tsv outputs.
 
         options "-stub"
 
@@ -180,7 +181,11 @@ nextflow_workflow {
                     "HLA-A24:02,HLA-A24:02,HLA-B39:01,HLA-B39:01,HLA-C07:01,HLA-C06:02",
                     ])
 
-                input[1] = channel.empty()
+                input[1] = channel.value([
+                    [ id:'test', single_end:false ], // meta map
+                    [],
+                    []
+                    ])
                 """
             }
         }
@@ -191,7 +196,11 @@ nextflow_workflow {
                 { assert snapshot(workflow.out.tsv[0][0],
                                   file(workflow.out.tsv[0][1]).name,
                                   workflow.out.tsv[1][0],
-                                  file(workflow.out.tsv[1][1]).name
+                                  file(workflow.out.tsv[1][1]).name,
+                                  workflow.out.tsv[2][0],
+                                  file(workflow.out.tsv[2][1]).name,
+                                  workflow.out.tsv[3][0],
+                                  file(workflow.out.tsv[3][1]).name
                                   ).match()
                 }
             )

--- a/subworkflows/msk/netmhcstabandpan/tests/main.nf.test.snap
+++ b/subworkflows/msk/netmhcstabandpan/tests/main.nf.test.snap
@@ -213,7 +213,7 @@
         },
         "timestamp": "2025-12-19T14:22:41.854041255"
     },
-    "netmhcstabandpan - empty SV channel - fa,hla_str - tsv - stub": {
+    "netmhcstabandpan - padded empty SV placeholder - fa,hla_str - tsv - stub": {
         "content": [
             {
                 "id": "test",
@@ -230,12 +230,28 @@
                 "fromStab": true,
                 "typePan": true
             },
-            "test.WT.STAB.tsv"
+            "test.WT.STAB.tsv",
+            {
+                "id": "test",
+                "single_end": false,
+                "typeMut": true,
+                "fromStab": false,
+                "typePan": true
+            },
+            "test.MUT.PAN.tsv",
+            {
+                "id": "test",
+                "single_end": false,
+                "typeMut": true,
+                "fromStab": true,
+                "typePan": true
+            },
+            "test.MUT.STAB.tsv"
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.2"
         },
-        "timestamp": "2026-05-13T22:29:19.315483"
+        "timestamp": "2026-05-27T16:15:00.000000000"
     }
 }


### PR DESCRIPTION
## Problem
PR #246 added `remainder: true` to the SV-fasta join in
`NETMHCSTABANDPAN.createNETMHCInput` so samples without SV data wouldn't
be silently dropped. The fix was correct, but `remainder: true` buffers
each unmatched item until the right-side channel **closes** — which
doesn't happen until `GENERATE_MUTATED_PEPTIDES` finishes emitting,
which is gated on the slowest `GENERATEMUTFASTA` across the whole
cohort.

Visible symptom in neoantigenpipeline: no sample's netMHC tasks start
until *every* sample's `GENERATEMUTFASTA` has completed.

## Fix
Move the "keep samples without SV" responsibility upstream into
`GENERATE_MUTATED_PEPTIDES`:

- Branch `ch_sv` into `with_sv` (runs `NEOSV` as before) and `without_sv`
  (emits `[meta, []]` placeholders).
- Mix both into `sv_mut_fasta` / `sv_wt_fasta` so each sample has exactly
  one entry on the SV outputs.

`NETMHCSTABANDPAN.createNETMHCInput` can then go back to a plain inner
`.join(sv_fastas_channel, by:0)`. Every sample matches; items flow
per-sample as soon as their fastas are ready.

## Verification
Ran neoantigenpipeline (`-profile test,docker`) with a 2-sample sheet
(one full-size MAF, one 1-variant MAF) before and after the fix and
compared task timestamps from `.nextflow.log`:

| Run                          | sample_tiny GENERATEMUTFASTA done | First NETMHC submitted | Gap     |
|------------------------------|-----------------------------------|------------------------|---------|
| Baseline (`remainder: true`) | 14:18:46.074                      | 14:19:00.076           | ~14.0 s |
| Fixed                        | 13:43:43.426                      | 13:43:43.549           | ~0.12 s |

The 14 s gap in baseline maps almost exactly to the runtime of the
other sample's `NETMHC3` task — that's the cross-sample serialization
this PR removes.

The existing "empty SV channel" regression test from #246 still passes
— the subworkflow continues to tolerate an empty SV channel as a
defensive contract, even though callers are now expected to pre-pad.

## Followup
Once merged, neoantigenpipeline needs the usual `modules.json` bump +
re-sync of the two subworkflow files (same shape as commit 257659f in
the pipeline that pulled in #246).

- [ ] This comment contains a description of changes (with reason).
- [ ] Check to see if a [nf-core module, or subworkflow](https://github.com/nf-core/modules) is available and usable for your pipeline.
- [ ] Feature branch is named `feature/<module_name>` for modules, or `feature/<subworkflow_name>` for subworkflows. For modules, if there is a subcommand use: `feature/<module_name>/<module_subcommand>`.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://mskcc-omics-workflows.gitbook.io/omics-wf/GMaCKqX0TmAhUOoZmuc6).
- [ ] Use [nf-core data](https://github.com/nf-core/test-datasets) if possible for nf-tests. If not, use or add test data to [mskcc-omics-workflows/test-datasets](https://github.com/mskcc-omics-workflows/test-datasets), following the repository guidelines, for nf-tests. Finally, if neither option is feasible, only add a stub nf-test.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`.
- [ ] Use Jfrog if possible to fulfill software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <module_branch> test <MODULE> --profile docker`
    - [ ] `nf-core modules --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <module_branch> test <MODULE> --profile singularity`
    - [ ] `nf-core modules --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <module_branch> test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <subworkflow_branch> test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <subworkflow_branch> test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows --git-remote https://github.com/mskcc-omics-workflows/modules.git -b <subworkflow_branch> test <SUBWORKFLOW> --profile conda`
