### PR TITLE
Update Genome Nexus annotation module args

### DIFF
--- a/modules/msk/genomenexus/annotationpipeline/main.nf
+++ b/modules/msk/genomenexus/annotationpipeline/main.nf
@@ -20,9 +20,15 @@ process GENOMENEXUS_ANNOTATIONPIPELINE {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def xms = Math.max(256, (task.memory.toMega() / 4) as int)
+    def xmx = Math.max(1, task.memory.toGiga() as int)
 
     """
-    java -Xms${task.memory.toMega()/4}m -Xmx${task.memory.toGiga()}g -jar /genome-nexus-annotation-pipeline/annotationPipeline/target/annotationPipeline.jar --filename ${input_maf} --output-filename ${meta.id}-annotated.maf
+    java -Xms${xms}m -Xmx${xmx}g \\
+        -jar /genome-nexus-annotation-pipeline/annotationPipeline/target/annotationPipeline.jar \\
+        --filename ${input_maf} \\
+        --output-filename ${prefix}-annotated.maf \\
+        ${args}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -31,15 +37,14 @@ process GENOMENEXUS_ANNOTATIONPIPELINE {
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
-    touch ${meta.id}-annotated.maf
+    touch ${prefix}-annotated.maf
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        genomenexus: 'annotation pipeline version 1.0.5
+        genomenexus: 'annotationpipeline version 1.0.5'
     END_VERSIONS
     """
 }

--- a/modules/msk/genomenexus/annotationpipeline/tests/main.nf.test
+++ b/modules/msk/genomenexus/annotationpipeline/tests/main.nf.test
@@ -41,16 +41,15 @@ nextflow_process {
 
     test("test normal - stub") {
 
+        tag "stub"
         options "-stub"
 
         when {
             process {
                 """
-
-
                 input[0] = [
                     [ id:'test',case_id:'sample1',control_id:'sample2'], // meta map
-                    file(params.test_data_mskcc['genome_nexus']['sample2_sample1_annotated_maf'], checkIfExists: true)
+                    file('dummy.maf', checkIfExists: false)
                     ]
                 """
             }
@@ -58,7 +57,8 @@ nextflow_process {
 
         then {
             assertAll(
-                { assert process.success }
+                { assert process.success },
+                { assert snapshot(process.out).match() }
 
             )
         }

--- a/modules/msk/genomenexus/annotationpipeline/tests/main.nf.test.snap
+++ b/modules/msk/genomenexus/annotationpipeline/tests/main.nf.test.snap
@@ -9,7 +9,7 @@
                             "case_id": "sample1",
                             "control_id": "sample2"
                         },
-                        "test-annotated.maf:md5,4547e768939e82f6d1f44e1c64b64c3a"
+                        "test-annotated.maf:md5,a8b47024c381dc8f2e5b2c0da0b24029"
                     ]
                 ],
                 "1": [
@@ -22,7 +22,7 @@
                             "case_id": "sample1",
                             "control_id": "sample2"
                         },
-                        "test-annotated.maf:md5,4547e768939e82f6d1f44e1c64b64c3a"
+                        "test-annotated.maf:md5,a8b47024c381dc8f2e5b2c0da0b24029"
                     ]
                 ],
                 "versions": [
@@ -34,7 +34,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.10.3"
         },
-        "timestamp": "2024-11-26T16:50:32.331962"
+        "timestamp": "2026-06-10T11:03:28.679902"
     },
     "test normal - stub": {
         "content": [

--- a/modules/msk/genomenexus/annotationpipeline/tests/main.nf.test.snap
+++ b/modules/msk/genomenexus/annotationpipeline/tests/main.nf.test.snap
@@ -30,6 +30,47 @@
                 ]
             }
         ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.3"
+        },
         "timestamp": "2024-11-26T16:50:32.331962"
+    },
+    "test normal - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "case_id": "sample1",
+                            "control_id": "sample2"
+                        },
+                        "test-annotated.maf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,3eec02db5105ee47caf6ea6efb53f12c"
+                ],
+                "annotated_maf": [
+                    [
+                        {
+                            "id": "test",
+                            "case_id": "sample1",
+                            "control_id": "sample2"
+                        },
+                        "test-annotated.maf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,3eec02db5105ee47caf6ea6efb53f12c"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-06-09T17:03:25.918345"
     }
 }


### PR DESCRIPTION
## Summary

- Add support for `task.ext.args` in the Genome Nexus annotation pipeline module command
- Use `task.ext.prefix` for the annotated MAF output name
- Keep the existing container pinned to `ghcr.io/msk-access/genomenexus_annotation-pipeline:1.0.5`
- Fix the stub `versions.yml` rendering and add/update the nf-test stub snapshot
- Change the stub test input to `file('dummy.maf', checkIfExists: false)` because the stub block does not read the input MAF; the normal test still exercises a real MAF through the existing test-data fixture

## Container note

This PR intentionally keeps the old container while the rebuilt Genome Nexus container is reviewed and built. Once the new container from mskcc-omics-workflows/containers#60 is available, this module can be switched to the updated `ghcr.io/mskcc-omics-workflows/genomenexus_annotation-pipeline:1.0.7` image.

## Output inspection

I ran the updated module locally with the existing `1.0.5` container and a local copy of the Genome Nexus fixture MAF because the configured raw GitHub test-data URL cannot address the slash branch currently used by the fixture.

The generated command includes the configured args:

```bash
java -Xms768m -Xmx3g \
    -jar /genome-nexus-annotation-pipeline/annotationPipeline/target/annotationPipeline.jar \
    --filename input.maf \
    --output-filename tiny-annotated.maf \
    --isoform-override mskcc --replace-symbol-entrez --post-interval-size 1
```

The output looked structurally correct:

- `tiny-annotated.maf` contains `#genome_nexus_version: 2.1.3` and `#isoform: mskcc`
- The fixture output has 4 data rows, matching the input row count
- The two TP53 rows were annotated successfully with TP53/7157, `splice_donor_variant`, `Splice_Site`, dbSNP, HGVSc, transcript, and RefSeq fields populated
- The TERT and MET rows were emitted with `Annotation_Status=FAILED`, matching the tool log summary of 2 failed annotations

One caveat: the Genome Nexus jar logs an initial failed default batch attempt before the parameterized job completes successfully. The final parameterized job completed and Nextflow exited successfully. The current expected annotated fixture fetched from `test-datasets` appears stale or unannotated because it matches the input and differs from the real generated output.

## Validation

- `PATH=/Users/orgeraj/miniconda3/bin:$PATH NXF_DISABLE_CHECK_LATEST=true nf-test test modules/msk/genomenexus/annotationpipeline/tests/main.nf.test --tag stub --ci`
- `PATH=/Users/orgeraj/miniconda3/bin:$PATH NXF_DISABLE_CHECK_LATEST=true nf-test test --profile=docker --ci --shard 1/5 --filter process,workflow modules/msk/genomenexus/annotationpipeline/tests/main.nf.test --verbose`
- Local fixture run through Nextflow using `ghcr.io/msk-access/genomenexus_annotation-pipeline:1.0.5`
- GitHub PR #249 nf-test matrix passed after updating the normal-test snapshot
- Sensitive-pattern check on touched module files
