### PR TITLE
generatemutfasta 1.3: multi-transcript neoantigen peptides + resilience fixes

### DIFF
--- a/modules/msk/generatemutfasta/1.3/environment.yml
+++ b/modules/msk/generatemutfasta/1.3/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "YOUR-TOOL=HERE"

--- a/modules/msk/generatemutfasta/1.3/main.nf
+++ b/modules/msk/generatemutfasta/1.3/main.nf
@@ -1,0 +1,63 @@
+process GENERATEMUTFASTA {
+    tag "$meta.id"
+    label 'process_single'
+    container "ghcr.io/mskcc-omics-workflows/neoantigen-utils-base:1.4.0"
+
+    input:
+    tuple val(meta),  path(inputMaf)
+    path(mutalyzer_cache)
+
+    output:
+    tuple val(meta), path("*_out/*.MUT.sequences.fa"),       emit: mut_fasta
+    tuple val(meta), path("*_out/*.WT.sequences.fa"),        emit: wt_fasta
+    tuple val(meta), path("*_out/*_generate_mut_fasta.log"), emit: mut_fasta_log
+    path "versions.yml",                                     emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    # Setup cache
+
+    mkdir -p \$(pwd)/mutalyzer_cache
+
+    tar -xzf ${mutalyzer_cache} -C \$(pwd)/mutalyzer_cache
+
+    cat <<-END_MUTALYZER_CONFIG > \$(pwd)/config.txt
+	MUTALYZER_CACHE_DIR = \$(pwd)/mutalyzer_cache/cache
+	MUTALYZER_FILE_CACHE_ADD = false
+	END_MUTALYZER_CONFIG
+
+    mkdir ${prefix}_out
+
+    MUTALYZER_SETTINGS="\$(pwd)/config.txt" generateMutFasta.py --sample_id ${prefix} \
+    --output_dir ${prefix}_out \
+    --maf_file ${inputMaf}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        generateMutFasta: \$(echo \$(generateMutFasta.py -v))
+        mutalyzer: \$(echo \$(mutalyzer_normalizer -v | tr '\n' ' ' | awk '{print \$3}'))
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+        mkdir ${prefix}_out
+        touch ${prefix}_out/${prefix}.MUT.sequences.fa
+        touch ${prefix}_out/${prefix}.WT.sequences.fa
+        touch ${prefix}_out/${prefix}_generate_mut_fasta.log
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            generateMutFasta: \$(echo \$(generateMutFasta.py -v))
+            mutalyzer: \$(echo \$(mutalyzer_normalizer -v | tr '\n' ' ' | awk '{print \$3}'))
+        END_VERSIONS
+    """
+}

--- a/modules/msk/generatemutfasta/1.3/main.nf
+++ b/modules/msk/generatemutfasta/1.3/main.nf
@@ -11,6 +11,9 @@ process GENERATEMUTFASTA {
     tuple val(meta), path("*_out/*.MUT.sequences.fa"),       emit: mut_fasta
     tuple val(meta), path("*_out/*.WT.sequences.fa"),        emit: wt_fasta
     tuple val(meta), path("*_out/*_generate_mut_fasta.log"), emit: mut_fasta_log
+    tuple val(meta), path("*_out/*.altMUT.fa"),              emit: alt_mut_fasta,  optional: true
+    tuple val(meta), path("*_out/*.altWT.fa"),               emit: alt_wt_fasta,   optional: true
+    tuple val(meta), path("*_out/*.transcript_map.tsv"),     emit: transcript_map, optional: true
     path "versions.yml",                                     emit: versions
 
     when:
@@ -36,7 +39,8 @@ process GENERATEMUTFASTA {
 
     MUTALYZER_SETTINGS="\$(pwd)/config.txt" generateMutFasta.py --sample_id ${prefix} \
     --output_dir ${prefix}_out \
-    --maf_file ${inputMaf}
+    --maf_file ${inputMaf} \
+    ${args}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -48,12 +52,14 @@ process GENERATEMUTFASTA {
     stub:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def alt_stub = args.contains('--multi_transcript') ? "touch ${prefix}_out/${prefix}.altMUT.fa ${prefix}_out/${prefix}.altWT.fa ${prefix}_out/${prefix}.transcript_map.tsv" : ''
 
     """
         mkdir ${prefix}_out
         touch ${prefix}_out/${prefix}.MUT.sequences.fa
         touch ${prefix}_out/${prefix}.WT.sequences.fa
         touch ${prefix}_out/${prefix}_generate_mut_fasta.log
+        ${alt_stub}
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
             generateMutFasta: \$(echo \$(generateMutFasta.py -v))

--- a/modules/msk/generatemutfasta/1.3/meta.yml
+++ b/modules/msk/generatemutfasta/1.3/meta.yml
@@ -1,0 +1,78 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "neoantigenutils_generatemutfasta"
+description: Generate the mutation fasta for netmhc tools
+keywords:
+  - neoantigen
+  - fasta
+  - netmhc
+  - mutation
+  - hgvsc
+  - Mutalyzer
+tools:
+  - neoantigen_utils:
+      description: "Collection of helper scripts for neoantigen processing"
+      documentation: "https://github.com/mskcc-omics-workflows/modules"
+      licence: [""]
+      identifier: ""
+  - mutalyzer:
+      description: "A tool primarily designed to check descriptions of sequence variants according to the Human Genome Sequence Variation Society (HGVS) guidelines."
+      documentation: "https://mutalyzer.readthedocs.io/en/latest/"
+      licence: ["MIT"]
+      identifier: ""
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information.
+          e.g. `[ id:'sample1', single_end:false ]`
+    - inputMaf:
+        type: file
+        description: Maf outputtted by Tempo that was run through phyloWGS
+        pattern: "*.maf"
+  - - mutalyzer_cache:
+        type: file
+        description: Mutatalyzer cache to use with the normalizer
+        pattern: "*.tar.gz"
+output:
+  - mut_fasta:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*_out/*.MUT.sequences.fa":
+          type: file
+          description: Mutated fasta sequence
+          pattern: "*.MUT.sequences.fa"
+  - wt_fasta:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*_out/*.WT.sequences.fa":
+          type: file
+          description: Wildtype fasta sequence
+          pattern: "*.WT.sequences.fa"
+  - mut_fasta_log:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*_out/*_generate_mut_fasta.log":
+          type: file
+          description: Log file for the mutated fasta generation
+          pattern: "*_generate_mut_fasta.log"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@johnoooh"
+  - "@nikhil"
+maintainers:
+  - "@johnoooh"
+  - "@nikhil"

--- a/modules/msk/generatemutfasta/1.3/meta.yml
+++ b/modules/msk/generatemutfasta/1.3/meta.yml
@@ -65,6 +65,43 @@ output:
           type: file
           description: Log file for the mutated fasta generation
           pattern: "*_generate_mut_fasta.log"
+  - alt_mut_fasta:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*_out/*.altMUT.fa":
+          type: file
+          description: |
+            Net-new mutated peptides from alternate transcripts, with integer
+            surrogate headers. Only produced when --multi_transcript is set.
+          pattern: "*.altMUT.fa"
+  - alt_wt_fasta:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*_out/*.altWT.fa":
+          type: file
+          description: |
+            Representative wildtype peptides paired by surrogate to the alt
+            mutated peptides. Only produced when --multi_transcript is set.
+          pattern: "*.altWT.fa"
+  - transcript_map:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*_out/*.transcript_map.tsv":
+          type: file
+          description: |
+            Provenance side-car mapping each (mutation, qualifying transcript)
+            to its consequence, RefSeq, same-as-annotated flag and surrogate id.
+            Only produced when --multi_transcript is set.
+          pattern: "*.transcript_map.tsv"
   - versions:
       - versions.yml:
           type: file

--- a/modules/msk/generatemutfasta/1.3/resources/usr/bin/generateMutFasta.py
+++ b/modules/msk/generatemutfasta/1.3/resources/usr/bin/generateMutFasta.py
@@ -8,7 +8,33 @@ import pandas as pd
 import logging
 from mutalyzer.normalizer import normalize
 
-VERSION = 1.2
+VERSION = 1.3
+
+# Effect terms that can yield a neoantigen, matched case-insensitively as
+# substrings of the effect field. Genome Nexus' ``Additional_Transcripts``
+# column reports MAF ``Variant_Classification`` values (e.g. Missense_Mutation),
+# so those are covered here; the VEP consequence terms are kept as well so the
+# check also works if fed a raw VEP consequence.
+NEOANTIGEN_CAPABLE_CONSEQUENCES = (
+    # VEP consequence terms
+    "missense",
+    "inframe_insertion",
+    "inframe_deletion",
+    "frameshift",
+    "stop_gained",
+    "stop_lost",
+    "start_lost",
+    "protein_altering",
+    "splice_acceptor",
+    "splice_donor",
+    # MAF Variant_Classification terms (Genome Nexus Additional_Transcripts)
+    "in_frame",
+    "frame_shift",
+    "nonsense",
+    "nonstop",
+    "translation_start_site",
+    "splice_site",
+)
 
 #######################
 ### FASTA with mutated peptides
@@ -54,6 +80,13 @@ def main():
         help="comma-separated numbers indicating the lengths of peptides to generate. Default: 9,10",
     )
     optional_arguments.add_argument(
+        "--multi_transcript",
+        action="store_true",
+        help="Also generate neoantigen peptides for the alternate (non-annotated) "
+        "transcripts listed in the MAF Additional_Transcripts column "
+        "(Genome Nexus -m extended).",
+    )
+    optional_arguments.add_argument(
         "-v", "--version", action="version", version="%(prog)s {}".format(VERSION)
     )
 
@@ -62,6 +95,7 @@ def main():
     maf_file = str(args.maf_file)
     output_dir = str(args.output_dir)
     sample_id = str(args.sample_id)
+    multi_transcript = bool(args.multi_transcript)
     peptide_lengths = [9, 10, 11]
     sample_path_pfx = output_dir + "/" + sample_id
     mutated_sequences_fa = sample_path_pfx + ".MUT.sequences.fa"
@@ -103,6 +137,17 @@ def main():
             maf_file, "#", low_memory=False, header=0, sep="\t"
         )
         n_muts = n_non_syn_muts = n_missing_tx_id = 0
+
+        # Multi-transcript accumulators (only populated/written when --multi_transcript).
+        # surrogate_by_seq maps a net-new alt MUT window sequence to its integer
+        # surrogate label (global dedup across the sample), so the same peptide is
+        # only scored once by netMHC. map_rows collects one row per
+        # (mutation, qualifying transcript) for the transcript_map.tsv side-car.
+        surrogate_by_seq = {}
+        surrogate_wt = {}
+        map_rows = []
+        alt_memo = {}
+
         for _, row in maf_df.iterrows():
 
             n_muts += 1
@@ -118,22 +163,9 @@ def main():
                 n_missing_tx_id += 1
 
             if len(mut.mt_altered_aa) > 5:
-                id_string = (
-                    str(mut.maf_row["Transcript_ID"])
-                    + " Variant "
-                    + str(mut.maf_row["Chromosome"])
-                    + ":"
-                    + str(mut.maf_row["Start_Position"])
-                    + "-"
-                    + str(mut.maf_row["End_Position"])
-                    + " Ref:"
-                    + str(mut.maf_row["Reference_Allele"])
-                    + " Alt:"
-                    + str(mut.maf_row["Tumor_Seq_Allele2"])
-                )
-                out_fa.write(">" + id_string + "\n")
+                out_fa.write(">" + mut.identifier_key + "_M\n")
                 out_fa.write(mut.mt_altered_aa + "\n")
-                out_WT_fa.write(">" + id_string + "\n")
+                out_WT_fa.write(">" + mut.identifier_key + "_W\n")
                 out_WT_fa.write(mut.wt_altered_aa + "\n")
 
                 ### write out WT/MT CDS + AA for debugging purposes
@@ -143,8 +175,24 @@ def main():
                 debug_out_fa.write("mt_full_aa: " + mut.mt_aa + "\n")
             mutations.append(mut)
 
+            if multi_transcript:
+                process_alt_transcripts(
+                    mut,
+                    max(peptide_lengths),
+                    surrogate_by_seq,
+                    surrogate_wt,
+                    map_rows,
+                    alt_memo,
+                )
+
         out_fa.close()
+        out_WT_fa.close()
         debug_out_fa.close()
+
+        if multi_transcript:
+            write_multi_transcript_outputs(
+                sample_path_pfx, surrogate_by_seq, surrogate_wt, map_rows
+            )
 
         logger.info("\tMAF mutations summary")
         logger.info("\t\t# mutations: " + str(n_muts))
@@ -155,6 +203,13 @@ def main():
             + str(n_missing_tx_id)
             + ")"
         )
+        if multi_transcript:
+            logger.info("\tMulti-transcript summary")
+            logger.info("\t\t# transcript_map rows: " + str(len(map_rows)))
+            logger.info(
+                "\t\t# net-new alt peptides (surrogates): "
+                + str(len(surrogate_by_seq))
+            )
 
     except Exception:
         logger.error("Error while generating mutated peptides")
@@ -174,6 +229,329 @@ def skip_lines_start_with(fle, junk, **kwargs):
             cur_line = f.readline()
         f.seek(pos)
         return pd.read_csv(f, **kwargs)
+
+
+#######################
+### Multi-transcript helpers (only exercised when --multi_transcript)
+#######################
+
+
+def parse_additional_transcripts(additional_transcripts):
+    """Parse the Genome Nexus ``Additional_Transcripts`` MAF column.
+
+    Genome Nexus (``-m extended``) emits this column as a ``;``-separated list of
+    the *alternate* transcripts for a variant -- the canonical transcript is NOT
+    included here (it lives in the main MAF columns). Each entry is a
+    ``,``-separated record with the fields, in order,
+    ``Transcript_ID,Hugo_Symbol,HGVSp_Short,HGVSc,Variant_Classification`` (e.g.
+    ``ENST00000379389,ISG15,p.Ile36=,c.106A>G,Silent``).
+
+    The returned tuple keeps the shape the rest of this module expects,
+    ``(symbol, consequence, hgvsp_short, transcript_id, refseq, hgvsc)``, where
+    ``consequence`` is the MAF ``Variant_Classification`` and ``refseq`` is ``""``
+    (Genome Nexus does not emit a per-transcript RefSeq in this column). HGVSc is
+    taken from its fixed position but falls back to a ``c.``/``n.`` prefix search
+    so a future column-order change does not silently drop it.
+
+    Trailing/empty entries and short/malformed records are tolerated and skipped.
+    Records without a transcript id are skipped.
+    """
+    effects = []
+    if additional_transcripts is None or pd.isnull(additional_transcripts):
+        return effects
+    for chunk in str(additional_transcripts).split(";"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        fields = [f.strip() for f in chunk.split(",")]
+        # need at least Transcript_ID,Hugo_Symbol,HGVSp_Short,HGVSc
+        if len(fields) < 4:
+            continue
+        transcript_id = fields[0]
+        symbol = fields[1]
+        hgvsp_short = fields[2]
+        # HGVSc is field 3, but locate it by its "c."/"n." prefix if that slot
+        # does not look like an HGVSc (robust to column-order changes).
+        hgvsc = fields[3] if fields[3].startswith(("c.", "n.")) else next(
+            (f for f in fields if f.startswith(("c.", "n."))),
+            "",
+        )
+        consequence = fields[4] if len(fields) >= 5 else ""
+        refseq = ""
+        if not transcript_id:
+            continue
+        effects.append(
+            (symbol, consequence, hgvsp_short, transcript_id, refseq, hgvsc)
+        )
+    return effects
+
+
+def is_neoantigen_capable(consequence):
+    """True if the VEP consequence can yield a neoantigen (case-insensitive)."""
+    if not consequence:
+        return False
+    c = consequence.lower()
+    return any(term in c for term in NEOANTIGEN_CAPABLE_CONSEQUENCES)
+
+
+def normalize_to_windows(transcript_id, hgvsc, pad_len):
+    """Build the WT/MT peptide windows for ``transcript_id:hgvsc``.
+
+    Uses the per-transcript HGVSc emitted by Genome Nexus (in
+    ``Additional_Transcripts``) and the SAME Mutalyzer ``normalize`` call as the
+    annotated single-transcript
+    path -- there is no genomic crossmapping, so this is robust for
+    missense/indel/frameshift alike and needs no genomic reference in the cache.
+
+    Returns ``(wt_window, mt_window)``. On any failure (missing/invalid HGVSc,
+    Mutalyzer error, missing protein, exception) a warning is logged and
+    ``(None, None)`` is returned so the caller skips the transcript; this
+    function never raises.
+    """
+    if not hgvsc or "c" not in str(hgvsc):
+        return None, None
+    try:
+        response = normalize(f"{transcript_id}:{hgvsc}")
+        if "errors" in response:
+            error_obj = response["errors"][0]
+            logger.warning(
+                "Mutalyzer error for alt transcript "
+                + f"{transcript_id}:{hgvsc}: "
+                + str(error_obj.get("code", ""))
+                + ", "
+                + str(error_obj.get("details", ""))
+            )
+            return None, None
+        protein = response.get("protein")
+        if not protein or "predicted" not in protein or "reference" not in protein:
+            logger.warning(
+                "No protein prediction for alt transcript "
+                + f"{transcript_id}:{hgvsc}"
+            )
+            return None, None
+        return extract_altered_windows(
+            protein["reference"], protein["predicted"], pad_len
+        )
+    except Exception:
+        logger.warning(
+            "Failed to build peptide for alt transcript "
+            + f"{transcript_id}:{hgvsc}; skipping\n"
+            + traceback.format_exc()
+        )
+        return None, None
+
+
+def process_alt_transcripts(
+    mut, pad_len, surrogate_by_seq, surrogate_wt, map_rows, alt_memo
+):
+    """Enumerate, build and collapse alternate transcripts for one mutation.
+
+    Reads the mutation's ``Additional_Transcripts`` column, keeps only
+    neoantigen-capable consequences, builds each surviving alt transcript's peptide from its
+    Genome-Nexus-supplied ``transcript:HGVSc`` via the same Mutalyzer
+    ``normalize`` call as the annotated path (memoized by
+    ``(transcript_id, hgvsc)``), compares each alt MUT window to the annotated
+    MUT window (``same_as_annotated``), assigns surrogate integers to net-new MUT
+    windows, and appends one ``map_rows`` entry per (mutation, qualifying
+    transcript).
+
+    The annotated transcript is recorded in the map (``is_annotated=True``,
+    ``same_as_annotated=True``, blank surrogate) but is NOT re-built -- its
+    window comes from the already-computed primary path.
+    """
+    row = mut.maf_row
+    annotated_transcript = str(row["Transcript_ID"])
+    annotated_mut_window = mut.mt_altered_aa
+
+    mutation_id = (
+        str(row["Chromosome"])
+        + "_"
+        + str(row["Start_Position"])
+        + "_"
+        + str(row["Reference_Allele"])
+        + "_"
+        + str(row["Tumor_Seq_Allele2"])
+    )
+
+    # Always record the annotated (canonical) transcript. Genome Nexus'
+    # Additional_Transcripts column lists only the *alternate* transcripts, so
+    # the canonical one is taken from the main MAF columns here rather than being
+    # found among the parsed alternates. Its window is the already-computed
+    # primary window, so it is not re-built.
+    if annotated_transcript and annotated_transcript.lower() != "nan":
+        map_rows.append(
+            {
+                "mutation_id": mutation_id,
+                "identifier_key": mut.identifier_key,
+                "transcript_id": annotated_transcript,
+                "refseq": row.get("RefSeq", "") if hasattr(row, "get") else "",
+                "is_annotated": True,
+                "consequence": (
+                    row.get("Variant_Classification", "")
+                    if hasattr(row, "get")
+                    else ""
+                ),
+                "hgvsp_short": (
+                    row.get("HGVSp_Short", "") if hasattr(row, "get") else ""
+                ),
+                "same_as_annotated": True,
+                "surrogate_id": "",
+            }
+        )
+
+    additional_transcripts = (
+        row.get("Additional_Transcripts")
+        if hasattr(row, "get")
+        else row["Additional_Transcripts"]
+    )
+    effects = parse_additional_transcripts(additional_transcripts)
+    if not effects:
+        logger.warning(
+            "multi_transcript: no alternate transcripts in Additional_Transcripts "
+            + "for "
+            + mutation_id
+            + "; using single-transcript behavior for this mutation"
+        )
+        return
+
+    for symbol, consequence, hgvsp_short, transcript_id, refseq, hgvsc in effects:
+        # Genome Nexus excludes the canonical transcript from this column, but
+        # skip it defensively if it ever appears (already recorded above) so the
+        # map never carries a duplicate annotated row.
+        if transcript_id == annotated_transcript:
+            continue
+
+        if not is_neoantigen_capable(consequence):
+            continue
+
+        if not hgvsc:
+            logger.warning(
+                "multi_transcript: no HGVSc in Additional_Transcripts for alt transcript "
+                + transcript_id
+                + " of "
+                + mutation_id
+                + "; skipping (Genome Nexus must emit per-transcript HGVSc)"
+            )
+            continue
+
+        memo_key = (transcript_id, hgvsc)
+        if memo_key in alt_memo:
+            wt_window, mt_window = alt_memo[memo_key]
+        else:
+            wt_window, mt_window = normalize_to_windows(
+                transcript_id, hgvsc, pad_len
+            )
+            alt_memo[memo_key] = (wt_window, mt_window)
+
+        if wt_window is None or mt_window is None:
+            continue
+
+        # Skip windows too short to be peptides (mirrors the primary path's >5 gate).
+        if len(mt_window) <= 5:
+            continue
+
+        # An alt transcript whose MUT window equals its own WT window is silent at
+        # that transcript -> not a neoantigen; skip it entirely.
+        if mt_window == wt_window:
+            continue
+
+        same_as_annotated = mt_window == annotated_mut_window
+
+        if same_as_annotated:
+            surrogate_id = ""
+        else:
+            # Net-new MUT peptide. Dedup by (mutation, sequence) so a surrogate
+            # never spans two different mutations (which would mis-map downstream);
+            # identical net-new peptides across transcripts of the SAME mutation
+            # still share one surrogate and collapse into a single entry.
+            surr_key = (mutation_id, mt_window)
+            surrogate_id = surrogate_by_seq.get(surr_key)
+            if surrogate_id is None:
+                surrogate_id = str(len(surrogate_by_seq) + 1)
+                surrogate_by_seq[surr_key] = surrogate_id
+                # Representative WT window for this surrogate (first one wins).
+                surrogate_wt[surrogate_id] = wt_window
+
+        map_rows.append(
+            {
+                "mutation_id": mutation_id,
+                "identifier_key": mut.identifier_key,
+                "transcript_id": transcript_id,
+                "refseq": refseq,
+                "is_annotated": False,
+                "consequence": consequence,
+                "hgvsp_short": hgvsp_short,
+                "same_as_annotated": same_as_annotated,
+                "surrogate_id": surrogate_id,
+            }
+        )
+
+
+def write_multi_transcript_outputs(
+    sample_path_pfx, surrogate_by_seq, surrogate_wt, map_rows
+):
+    """Write the alt MUT/WT FASTAs and the transcript_map.tsv side-car.
+
+    - ``*.altMUT.fa``: one record per net-new MUT peptide, header
+      ``>`` + surrogate integer.
+    - ``*.altWT.fa``: the representative WT window per surrogate,
+      header ``>`` + surrogate integer.
+    - ``*.transcript_map.tsv``: tab-separated, with header, one row per
+      (mutation, qualifying transcript).
+
+    The alt FASTA names deliberately avoid the ``.MUT.sequences.fa`` /
+    ``.WT.sequences.fa`` suffixes so the primary mut_fasta/wt_fasta output globs
+    do not also capture them.
+    """
+    alt_mut_fa = sample_path_pfx + ".altMUT.fa"
+    alt_wt_fa = sample_path_pfx + ".altWT.fa"
+    transcript_map_tsv = sample_path_pfx + ".transcript_map.tsv"
+
+    # Only write the alt FASTAs when there is at least one net-new peptide, so an
+    # empty file is never handed to netMHC (which errors on empty input). The
+    # transcript_map is always written so corroboration annotation still works.
+    if surrogate_by_seq:
+        with open(alt_mut_fa, "w") as out_alt_mut, open(alt_wt_fa, "w") as out_alt_wt:
+            # Emit in surrogate order for deterministic output.
+            for surr_key, surrogate_id in sorted(
+                surrogate_by_seq.items(), key=lambda kv: int(kv[1])
+            ):
+                seq = surr_key[1]
+                out_alt_mut.write(">" + surrogate_id + "\n")
+                out_alt_mut.write(seq + "\n")
+                out_alt_wt.write(">" + surrogate_id + "\n")
+                out_alt_wt.write(surrogate_wt[surrogate_id] + "\n")
+
+    map_columns = [
+        "mutation_id",
+        "identifier_key",
+        "transcript_id",
+        "refseq",
+        "is_annotated",
+        "consequence",
+        "hgvsp_short",
+        "same_as_annotated",
+        "surrogate_id",
+    ]
+    with open(transcript_map_tsv, "w") as out_map:
+        out_map.write("\t".join(map_columns) + "\n")
+        for r in map_rows:
+            out_map.write(
+                "\t".join(
+                    [
+                        str(r["mutation_id"]),
+                        str(r["identifier_key"]),
+                        str(r["transcript_id"]),
+                        str(r["refseq"]),
+                        "True" if r["is_annotated"] else "False",
+                        str(r["consequence"]),
+                        str(r["hgvsp_short"]),
+                        "True" if r["same_as_annotated"] else "False",
+                        str(r["surrogate_id"]),
+                    ]
+                )
+                + "\n"
+            )
 
 
 #
@@ -221,11 +599,11 @@ class mutation(object):
 
         variant_type_map = {
             "missense_mutation": "M",
-            "nonsense_nutation": "X",
+            "nonsense_mutation": "X",
             "silent_mutation": "S",
             "silent": "S",
-            "frame_shift_ins": "I+",
-            "frame_shift_del": "I-",
+            "frame_shift_ins": "Fi",
+            "frame_shift_del": "Fd",
             "in_frame_ins": "If",
             "in_frame_del": "Id",
             "splice_site": "Sp",
@@ -326,44 +704,51 @@ class mutation(object):
         mt = mutalyzer_response["protein"]["predicted"]
         wt = mutalyzer_response["protein"]["reference"]
 
-        ### identify regions of mutation in WT and MT sequences.
-        ### logic is to match the wt and mt sequences first from the beginning until a mismatch is found; and, then,
-        ### start from the end of both sequences until a mismatch is found. the intervening sequence represents the WT and MT sequences
-        ### Note, aside from missenses, the interpretation of WT sequence is ambiguous.
-        len_from_start = len_from_end = 0
-
-        ## from start
-        for i in range(0, min(len(wt), len(mt))):
-            len_from_start = i
-            if wt[i : i + 1] != mt[i : i + 1]:
-                break
-
-        ## from end
-        wt_rev = wt[::-1]
-        mt_rev = mt[::-1]
-        for i in range(0, min(len(wt), len(mt))):
-            len_from_end = i
-            if (
-                len_from_end + len_from_start >= min(len(wt), len(mt))
-                or wt_rev[i : i + 1] != mt_rev[i : i + 1]
-            ):
-                break
-
-        wt_start = len_from_start
-        wt_end = len(wt) - len_from_end
-
-        mt_start = len_from_start
-        mt_end = len(mt) - len_from_end
-
         self.wt_aa = wt
         self.mt_aa = mt
 
-        self.wt_altered_aa = wt[
-            max(0, wt_start - pad_len + 1) : min(len(wt), wt_end + pad_len - 1)
-        ]
-        self.mt_altered_aa = mt[
-            max(0, mt_start - pad_len + 1) : min(len(mt), mt_end + pad_len - 1)
-        ]
+        self.wt_altered_aa, self.mt_altered_aa = extract_altered_windows(
+            wt, mt, pad_len
+        )
+
+
+# function that, given full WT and MT protein sequences, extracts the ± window
+# peptides around the altered region. Shared by the annotated path and the
+# multi-transcript alt path so both apply identical windowing.
+def extract_altered_windows(wt, mt, pad_len):
+    ### identify regions of mutation in WT and MT sequences.
+    ### logic is to match the wt and mt sequences first from the beginning until a mismatch is found; and, then,
+    ### start from the end of both sequences until a mismatch is found. the intervening sequence represents the WT and MT sequences
+    ### Note, aside from missenses, the interpretation of WT sequence is ambiguous.
+    len_from_start = len_from_end = 0
+
+    ## from start
+    for i in range(0, min(len(wt), len(mt))):
+        len_from_start = i
+        if wt[i : i + 1] != mt[i : i + 1]:
+            break
+
+    ## from end
+    wt_rev = wt[::-1]
+    mt_rev = mt[::-1]
+    for i in range(0, min(len(wt), len(mt))):
+        len_from_end = i
+        if (
+            len_from_end + len_from_start >= min(len(wt), len(mt))
+            or wt_rev[i : i + 1] != mt_rev[i : i + 1]
+        ):
+            break
+
+    wt_start = len_from_start
+    wt_end = len(wt) - len_from_end
+
+    mt_start = len_from_start
+    mt_end = len(mt) - len_from_end
+
+    wt_altered_aa = wt[max(0, wt_start - pad_len + 1) : min(len(wt), wt_end + pad_len - 1)]
+    mt_altered_aa = mt[max(0, mt_start - pad_len + 1) : min(len(mt), mt_end + pad_len - 1)]
+
+    return wt_altered_aa, mt_altered_aa
 
 
 if __name__ == "__main__":

--- a/modules/msk/generatemutfasta/1.3/resources/usr/bin/generateMutFasta.py
+++ b/modules/msk/generatemutfasta/1.3/resources/usr/bin/generateMutFasta.py
@@ -136,7 +136,7 @@ def main():
         maf_df = skip_lines_start_with(
             maf_file, "#", low_memory=False, header=0, sep="\t"
         )
-        n_muts = n_non_syn_muts = n_missing_tx_id = 0
+        n_muts = n_non_syn_muts = n_missing_tx_id = n_errored = 0
 
         # Multi-transcript accumulators (only populated/written when --multi_transcript).
         # surrogate_by_seq maps a net-new alt MUT window sequence to its integer
@@ -152,38 +152,52 @@ def main():
 
             n_muts += 1
 
-            mut = mutation(row)
+            try:
+                mut = mutation(row)
 
-            if mut.is_non_syn():
-                n_non_syn_muts += 1
+                if mut.is_non_syn():
+                    n_non_syn_muts += 1
 
-            response = mut.generate_translated_sequences(max(peptide_lengths))
+                response = mut.generate_translated_sequences(max(peptide_lengths))
 
-            if response == -1:
-                n_missing_tx_id += 1
+                if response == -1:
+                    n_missing_tx_id += 1
 
-            if len(mut.mt_altered_aa) > 5:
-                out_fa.write(">" + mut.identifier_key + "_M\n")
-                out_fa.write(mut.mt_altered_aa + "\n")
-                out_WT_fa.write(">" + mut.identifier_key + "_W\n")
-                out_WT_fa.write(mut.wt_altered_aa + "\n")
+                if len(mut.mt_altered_aa) > 5:
+                    out_fa.write(">" + mut.identifier_key + "_M\n")
+                    out_fa.write(mut.mt_altered_aa + "\n")
+                    out_WT_fa.write(">" + mut.identifier_key + "_W\n")
+                    out_WT_fa.write(mut.wt_altered_aa + "\n")
 
-                ### write out WT/MT CDS + AA for debugging purposes
-                debug_out_fa.write(">" + mut.identifier_key + "_M\n")
-                debug_out_fa.write("mt_altered_aa: " + mut.mt_altered_aa + "\n")
-                debug_out_fa.write("wt_full_aa: " + mut.wt_aa + "\n")
-                debug_out_fa.write("mt_full_aa: " + mut.mt_aa + "\n")
-            mutations.append(mut)
+                    ### write out WT/MT CDS + AA for debugging purposes
+                    debug_out_fa.write(">" + mut.identifier_key + "_M\n")
+                    debug_out_fa.write("mt_altered_aa: " + mut.mt_altered_aa + "\n")
+                    debug_out_fa.write("wt_full_aa: " + mut.wt_aa + "\n")
+                    debug_out_fa.write("mt_full_aa: " + mut.mt_aa + "\n")
+                mutations.append(mut)
 
-            if multi_transcript:
-                process_alt_transcripts(
-                    mut,
-                    max(peptide_lengths),
-                    surrogate_by_seq,
-                    surrogate_wt,
-                    map_rows,
-                    alt_memo,
+                if multi_transcript:
+                    process_alt_transcripts(
+                        mut,
+                        max(peptide_lengths),
+                        surrogate_by_seq,
+                        surrogate_wt,
+                        map_rows,
+                        alt_memo,
+                    )
+
+            except Exception as exc:
+                ## A failure on a single variant (e.g. an uncached transcript
+                ## triggering a live Ensembl fetch that times out) must not abort
+                ## the whole sample. Log, count, and skip this variant.
+                transcript = row.get("Transcript_ID", "<unknown>")
+                hgvsc = row.get("HGVSc", "<unknown>")
+                n_errored += 1
+                logger.warning(
+                    f"Skipping variant {transcript}:{hgvsc} due to error: {exc}"
                 )
+                logger.debug(traceback.format_exc())
+                continue
 
         out_fa.close()
         out_WT_fa.close()
@@ -203,6 +217,7 @@ def main():
             + str(n_missing_tx_id)
             + ")"
         )
+        logger.info("\t\t# skipped due to errors: " + str(n_errored))
         if multi_transcript:
             logger.info("\tMulti-transcript summary")
             logger.info("\t\t# transcript_map rows: " + str(len(map_rows)))
@@ -687,8 +702,18 @@ class mutation(object):
 
         hgvsc = self.maf_row["HGVSc"]
         transcript = self.maf_row["Transcript_ID"]
-        if hgvsc and "c" in str(hgvsc):
+        if hgvsc and "c" in str(hgvsc) and ":" not in str(hgvsc):
             mutalyzer_response = normalize(f"{transcript}:{hgvsc}")
+        elif ":" in str(hgvsc):
+            ## Strip the transcript version from a full-form HGVSc and re-build the
+            ## query from the VERSIONLESS Transcript_ID. A versioned reference makes
+            ## mutalyzer issue a per-transcript TARK/Ensembl network call (assembly /
+            ## most-recent-version check) even when the transcript is fully cached;
+            ## a versionless query resolves straight from the local file cache with
+            ## zero network. The cached model already corresponds to this version, so
+            ## the resulting protein is identical -- this is required for offline runs.
+            c_part = str(hgvsc).split(":", 1)[1]
+            mutalyzer_response = normalize(f"{transcript}:{c_part}")
         else:
             return None
         if "errors" in mutalyzer_response:
@@ -701,6 +726,14 @@ class mutation(object):
                 + error_obj["details"]
             )
             return -1
+
+        protein = mutalyzer_response.get("protein")
+        if not protein or "predicted" not in protein or "reference" not in protein:
+            logger.warning(
+                f"Mutalyzer: no protein consequence for {transcript}:{hgvsc}; skipping"
+            )
+            return -1
+
         mt = mutalyzer_response["protein"]["predicted"]
         wt = mutalyzer_response["protein"]["reference"]
 

--- a/modules/msk/generatemutfasta/1.3/resources/usr/bin/generateMutFasta.py
+++ b/modules/msk/generatemutfasta/1.3/resources/usr/bin/generateMutFasta.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import argparse
+import traceback
+import pandas as pd
+import logging
+from mutalyzer.normalizer import normalize
+
+VERSION = 1.2
+
+#######################
+### FASTA with mutated peptides
+#######################
+
+#
+# initialize loggers
+#
+logger = logging.getLogger("generate_fasta")
+logger.setLevel(logging.DEBUG)
+
+
+def main():
+    prog_description = "Construct mutated peptide sequences from HGVSc"
+    prog_epilog = "\n"
+
+    parser = argparse.ArgumentParser(
+        description=prog_description,
+        epilog=prog_epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        add_help=True,
+    )
+    required_arguments = parser.add_argument_group("Required arguments")
+    required_arguments.add_argument(
+        "--sample_id",
+        required=True,
+        help="sample_id used to limit neoantigen prediction to identify mutations "
+        "associated with the patient in the MAF (column 16). ",
+    )
+    required_arguments.add_argument(
+        "--output_dir", required=True, help="output directory"
+    )
+    required_arguments.add_argument(
+        "--maf_file",
+        required=True,
+        help="expects a maf file with HGVSc and transcripts",
+    )
+
+    optional_arguments = parser.add_argument_group("Optional arguments")
+    optional_arguments.add_argument(
+        "--peptide_lengths",
+        required=False,
+        help="comma-separated numbers indicating the lengths of peptides to generate. Default: 9,10",
+    )
+    optional_arguments.add_argument(
+        "-v", "--version", action="version", version="%(prog)s {}".format(VERSION)
+    )
+
+    args = parser.parse_args()
+
+    maf_file = str(args.maf_file)
+    output_dir = str(args.output_dir)
+    sample_id = str(args.sample_id)
+    peptide_lengths = [9, 10, 11]
+    sample_path_pfx = output_dir + "/" + sample_id
+    mutated_sequences_fa = sample_path_pfx + ".MUT.sequences.fa"
+    WT_sequences_fa = sample_path_pfx + ".WT.sequences.fa"
+
+    mutations = []
+    out_fa = open(mutated_sequences_fa, "w")
+    out_WT_fa = open(WT_sequences_fa, "w")
+
+    console_formatter = logging.Formatter(
+        "%(asctime)s: %(levelname)s: %(message)s", datefmt="%m-%d-%Y %H:%M:%S"
+    )
+
+    # logfile handler
+    log_file_name = f"{sample_id}_generate_mut_fasta.log"
+    handler_file = logging.FileHandler(output_dir + f"/{log_file_name}", mode="w")
+    handler_file.setLevel(logging.DEBUG)
+    handler_file.setFormatter(console_formatter)
+    logger.addHandler(handler_file)
+
+    # stdout handler
+    handler_stdout = logging.StreamHandler(sys.stdout)
+    handler_stdout.setFormatter(console_formatter)
+    handler_stdout.setLevel(logging.INFO)
+    logger.addHandler(handler_stdout)
+
+    logger.info("Starting generate mut fasta")
+    logger.info("\tLog file: " + output_dir + f"/{log_file_name}")
+    logger.info("\t--maf_file: " + maf_file)
+    logger.info("\t--output_dir: " + output_dir)
+
+    ## generate .debug.fa for debugging purposes.
+    debug_out_fa = open(sample_path_pfx + ".mutated_sequences.debug.fa", "w")
+
+    try:
+
+        logger.info("Reading MAF file and constructing mutated peptides...")
+        maf_df = skip_lines_start_with(
+            maf_file, "#", low_memory=False, header=0, sep="\t"
+        )
+        n_muts = n_non_syn_muts = n_missing_tx_id = 0
+        for _, row in maf_df.iterrows():
+
+            n_muts += 1
+
+            mut = mutation(row)
+
+            if mut.is_non_syn():
+                n_non_syn_muts += 1
+
+            response = mut.generate_translated_sequences(max(peptide_lengths))
+
+            if response == -1:
+                n_missing_tx_id += 1
+
+            if len(mut.mt_altered_aa) > 5:
+                id_string = (
+                    str(mut.maf_row["Transcript_ID"])
+                    + " Variant "
+                    + str(mut.maf_row["Chromosome"])
+                    + ":"
+                    + str(mut.maf_row["Start_Position"])
+                    + "-"
+                    + str(mut.maf_row["End_Position"])
+                    + " Ref:"
+                    + str(mut.maf_row["Reference_Allele"])
+                    + " Alt:"
+                    + str(mut.maf_row["Tumor_Seq_Allele2"])
+                )
+                out_fa.write(">" + id_string + "\n")
+                out_fa.write(mut.mt_altered_aa + "\n")
+                out_WT_fa.write(">" + id_string + "\n")
+                out_WT_fa.write(mut.wt_altered_aa + "\n")
+
+                ### write out WT/MT CDS + AA for debugging purposes
+                debug_out_fa.write(">" + mut.identifier_key + "_M\n")
+                debug_out_fa.write("mt_altered_aa: " + mut.mt_altered_aa + "\n")
+                debug_out_fa.write("wt_full_aa: " + mut.wt_aa + "\n")
+                debug_out_fa.write("mt_full_aa: " + mut.mt_aa + "\n")
+            mutations.append(mut)
+
+        out_fa.close()
+        debug_out_fa.close()
+
+        logger.info("\tMAF mutations summary")
+        logger.info("\t\t# mutations: " + str(n_muts))
+        logger.info(
+            "\t\t# non-syn: "
+            + str(n_non_syn_muts)
+            + " (# missing from cache: "
+            + str(n_missing_tx_id)
+            + ")"
+        )
+
+    except Exception:
+        logger.error("Error while generating mutated peptides")
+        logger.error(traceback.format_exc())
+        exit(1)
+
+
+# skip the header lines that start with "#"
+def skip_lines_start_with(fle, junk, **kwargs):
+    if os.stat(fle).st_size == 0:
+        raise ValueError("File is empty")
+    with open(fle) as f:
+        pos = 0
+        cur_line = f.readline()
+        while cur_line.startswith(junk):
+            pos = f.tell()
+            cur_line = f.readline()
+        f.seek(pos)
+        return pd.read_csv(f, **kwargs)
+
+
+#
+# mutation class holds each row in the maf
+#
+class mutation(object):
+    maf_row = None
+    wt_aa = ""
+    mt_altered_aa = ""
+    mt_altered_aa = ""
+    identifier_key = ""
+
+    def __init__(self, maf_row):
+        self.maf_row = maf_row
+
+        ##ENCODING FASTA ID FOR USE IN MATCHING LATER
+        ALPHABET = [
+            "A",
+            "B",
+            "C",
+            "D",
+            "E",
+            "F",
+            "G",
+            "H",
+            "I",
+            "J",
+            "K",
+            "L",
+            "M",
+            "N",
+            "O",
+            "P",
+            "Q",
+            "R",
+            "S",
+            "T",
+            "U",
+            "V",
+            "W",
+            "X",
+            "Y",
+            "Z",
+        ]
+
+        variant_type_map = {
+            "missense_mutation": "M",
+            "nonsense_nutation": "X",
+            "silent_mutation": "S",
+            "silent": "S",
+            "frame_shift_ins": "I+",
+            "frame_shift_del": "I-",
+            "in_frame_ins": "If",
+            "in_frame_del": "Id",
+            "splice_site": "Sp",
+        }
+
+        position = int(str(self.maf_row["Start_Position"])[0:2])
+
+        if position < 26:
+            encoded_start = ALPHABET[position]
+        elif position < 100:
+
+            encoded_start = ALPHABET[position // 4]
+
+        position = int(str(self.maf_row["Start_Position"])[-2:])
+
+        if position < 26:
+            encoded_end = ALPHABET[position]
+        elif position < 100:
+
+            encoded_end = ALPHABET[position // 4]
+
+        sum_remaining = sum(int(d) for d in str(self.maf_row["Start_Position"])[2:-2])
+
+        encoded_position = encoded_start + ALPHABET[sum_remaining % 26] + encoded_end
+
+        if self.maf_row["Tumor_Seq_Allele2"] == "-":
+            # handles deletion
+            if len(self.maf_row["Reference_Allele"]) > 3:
+                Allele2code = self.maf_row["Reference_Allele"][0:3]
+            else:
+                Allele2code = self.maf_row["Reference_Allele"]
+
+        elif len(self.maf_row["Tumor_Seq_Allele2"]) > 1:
+            # handles INS and DNP
+            if len(self.maf_row["Tumor_Seq_Allele2"]) > 3:
+                Allele2code = self.maf_row["Tumor_Seq_Allele2"][0:3]
+            else:
+                Allele2code = self.maf_row["Tumor_Seq_Allele2"]
+
+        else:
+            # SNPs
+            Allele2code = self.maf_row["Tumor_Seq_Allele2"]
+
+        if self.maf_row["Variant_Classification"].lower() in variant_type_map:
+            self.identifier_key = (
+                str(self.maf_row["Chromosome"])
+                + encoded_position
+                + "_"
+                + variant_type_map[(self.maf_row["Variant_Classification"]).lower()]
+                + Allele2code
+            )
+        else:
+
+            self.identifier_key = (
+                str(self.maf_row["Chromosome"])
+                + encoded_position
+                + "_"
+                + "SY"
+                + Allele2code
+            )
+
+    ### Check if the variant_classification is among those that can generate a neoantigen
+    def is_non_syn(self):
+        types = [
+            "Frame_Shift_Del",
+            "Frame_Shift_Ins",
+            "In_Frame_Del",
+            "In_Frame_Ins",
+            "Missense_Mutation",
+            "Nonstop_Mutation",
+        ]
+
+        return self.maf_row["Variant_Classification"] in types and not pd.isnull(
+            self.maf_row["HGVSp_Short"]
+        )
+
+    # function that parses the HGVSc and constructs the WT and mutated coding sequences for the given mutation.
+    def generate_translated_sequences(self, pad_len=10):
+        if not self.is_non_syn():
+            return None
+
+        hgvsc = self.maf_row["HGVSc"]
+        transcript = self.maf_row["Transcript_ID"]
+        if hgvsc and "c" in str(hgvsc):
+            mutalyzer_response = normalize(f"{transcript}:{hgvsc}")
+        else:
+            return None
+        if "errors" in mutalyzer_response:
+            error_obj = mutalyzer_response["errors"][0]
+            logger.warning(
+                "Mutalyzer error: "
+                + f"{transcript}:{hgvsc} "
+                + error_obj["code"]
+                + ", "
+                + error_obj["details"]
+            )
+            return -1
+        mt = mutalyzer_response["protein"]["predicted"]
+        wt = mutalyzer_response["protein"]["reference"]
+
+        ### identify regions of mutation in WT and MT sequences.
+        ### logic is to match the wt and mt sequences first from the beginning until a mismatch is found; and, then,
+        ### start from the end of both sequences until a mismatch is found. the intervening sequence represents the WT and MT sequences
+        ### Note, aside from missenses, the interpretation of WT sequence is ambiguous.
+        len_from_start = len_from_end = 0
+
+        ## from start
+        for i in range(0, min(len(wt), len(mt))):
+            len_from_start = i
+            if wt[i : i + 1] != mt[i : i + 1]:
+                break
+
+        ## from end
+        wt_rev = wt[::-1]
+        mt_rev = mt[::-1]
+        for i in range(0, min(len(wt), len(mt))):
+            len_from_end = i
+            if (
+                len_from_end + len_from_start >= min(len(wt), len(mt))
+                or wt_rev[i : i + 1] != mt_rev[i : i + 1]
+            ):
+                break
+
+        wt_start = len_from_start
+        wt_end = len(wt) - len_from_end
+
+        mt_start = len_from_start
+        mt_end = len(mt) - len_from_end
+
+        self.wt_aa = wt
+        self.mt_aa = mt
+
+        self.wt_altered_aa = wt[
+            max(0, wt_start - pad_len + 1) : min(len(wt), wt_end + pad_len - 1)
+        ]
+        self.mt_altered_aa = mt[
+            max(0, mt_start - pad_len + 1) : min(len(mt), mt_end + pad_len - 1)
+        ]
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/msk/generatemutfasta/1.3/tests/main.nf.test
+++ b/modules/msk/generatemutfasta/1.3/tests/main.nf.test
@@ -1,0 +1,91 @@
+nextflow_process {
+
+    name "Test Process GENERATEMUTFASTA"
+    script "../main.nf"
+    process "GENERATEMUTFASTA"
+
+    config "./nextflow.config"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "generatemutfasta/1.3"
+    tag "modules_msk"
+
+    test("generatemutfasta_1.3 - maf - fasta") {
+
+        setup {
+            run("MUTALYZER_RETRIEVER"){
+                script "../../../mutalyzer/retriever/main.nf"
+                process {
+                """
+
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.test_data_mskcc['neoantigen']['small_test_chr2and16']['fa_gzip'], checkIfExists: true),
+                    file(params.test_data_mskcc['neoantigen']['small_test_chr2and16']['gff3'], checkIfExists: true)
+                    ]
+
+                """
+                }
+
+            }
+        }
+
+        when {
+
+            process {
+                """
+
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.test_data_mskcc['neoantigen']['small_test_chr2and16']['somatic_filtered_maf'], checkIfExists: true)
+                    ]
+                input[1] = MUTALYZER_RETRIEVER.out.mutalyzer_cache
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(  process.out.versions,
+                                    process.out.mut_fasta,
+                                    process.out.wt_fasta,
+                                    file(process.out.mut_fasta_log[0][1]).name
+                                ).match()
+                }
+            )
+        }
+
+    }
+
+
+    test("generatemutfasta_1.3 - maf - fasta - stub") {
+
+        options "-stub"
+
+        when {
+
+            process {
+                """
+
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file('test.maf')
+                    ]
+                input[1] = file('test.tar.gz')
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+}

--- a/modules/msk/generatemutfasta/1.3/tests/main.nf.test
+++ b/modules/msk/generatemutfasta/1.3/tests/main.nf.test
@@ -88,4 +88,37 @@ nextflow_process {
         }
 
     }
+
+
+    test("generatemutfasta_1.3 - maf - multi_transcript - stub") {
+
+        options "-stub"
+        config "./nextflow_multi_transcript.config"
+
+        when {
+
+            process {
+                """
+
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file('test.maf')
+                    ]
+                input[1] = file('test.tar.gz')
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.alt_mut_fasta[0][1]).exists() },
+                { assert path(process.out.alt_wt_fasta[0][1]).exists() },
+                { assert path(process.out.transcript_map[0][1]).exists() },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
 }

--- a/modules/msk/generatemutfasta/1.3/tests/main.nf.test.snap
+++ b/modules/msk/generatemutfasta/1.3/tests/main.nf.test.snap
@@ -2,7 +2,7 @@
     "generatemutfasta_1.3 - maf - fasta": {
         "content": [
             [
-                "versions.yml:md5,825989b899b3a496c7a3e3560389a424"
+                "versions.yml:md5,4300bcc5423d50159c207868b7110d75"
             ],
             [
                 [
@@ -10,7 +10,7 @@
                         "id": "test",
                         "single_end": false
                     },
-                    "test.MUT.sequences.fa:md5,dff338ec438ac75aa674b64ea8e26544"
+                    "test.MUT.sequences.fa:md5,3d2ff66590a4329f9a24e03bdf84e0ab"
                 ]
             ],
             [
@@ -19,7 +19,7 @@
                         "id": "test",
                         "single_end": false
                     },
-                    "test.WT.sequences.fa:md5,51415a40a725a16eaa8f5c51fa43799e"
+                    "test.WT.sequences.fa:md5,4bfcfc4d29d01ddc4108f39350936228"
                 ]
             ],
             "test_generate_mut_fasta.log"
@@ -28,7 +28,132 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2026-07-22T11:19:00.334274"
+        "timestamp": "2026-07-22T11:28:00.201883"
+    },
+    "generatemutfasta_1.3 - maf - multi_transcript - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.MUT.sequences.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.WT.sequences.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_generate_mut_fasta.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.altMUT.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.altWT.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.transcript_map.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "6": [
+                    "versions.yml:md5,5d29840f07e139222a7e62cd6abe48af"
+                ],
+                "alt_mut_fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.altMUT.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "alt_wt_fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.altWT.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "mut_fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.MUT.sequences.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "mut_fasta_log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_generate_mut_fasta.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "transcript_map": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.transcript_map.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,5d29840f07e139222a7e62cd6abe48af"
+                ],
+                "wt_fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.WT.sequences.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2026-07-22T11:28:23.227188"
     },
     "generatemutfasta_1.3 - maf - fasta - stub": {
         "content": [
@@ -61,7 +186,22 @@
                     ]
                 ],
                 "3": [
-                    "versions.yml:md5,e653e8a2e136536d683b73afd3e0d00d"
+                    
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    "versions.yml:md5,5d29840f07e139222a7e62cd6abe48af"
+                ],
+                "alt_mut_fasta": [
+                    
+                ],
+                "alt_wt_fasta": [
+                    
                 ],
                 "mut_fasta": [
                     [
@@ -81,8 +221,11 @@
                         "test_generate_mut_fasta.log:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "transcript_map": [
+                    
+                ],
                 "versions": [
-                    "versions.yml:md5,e653e8a2e136536d683b73afd3e0d00d"
+                    "versions.yml:md5,5d29840f07e139222a7e62cd6abe48af"
                 ],
                 "wt_fasta": [
                     [
@@ -99,6 +242,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2026-07-22T11:19:12.010158"
+        "timestamp": "2026-07-22T11:28:11.91574"
     }
 }

--- a/modules/msk/generatemutfasta/1.3/tests/main.nf.test.snap
+++ b/modules/msk/generatemutfasta/1.3/tests/main.nf.test.snap
@@ -1,0 +1,104 @@
+{
+    "generatemutfasta_1.3 - maf - fasta": {
+        "content": [
+            [
+                "versions.yml:md5,825989b899b3a496c7a3e3560389a424"
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.MUT.sequences.fa:md5,dff338ec438ac75aa674b64ea8e26544"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.WT.sequences.fa:md5,51415a40a725a16eaa8f5c51fa43799e"
+                ]
+            ],
+            "test_generate_mut_fasta.log"
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2026-07-22T11:19:00.334274"
+    },
+    "generatemutfasta_1.3 - maf - fasta - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.MUT.sequences.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.WT.sequences.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_generate_mut_fasta.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    "versions.yml:md5,e653e8a2e136536d683b73afd3e0d00d"
+                ],
+                "mut_fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.MUT.sequences.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "mut_fasta_log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_generate_mut_fasta.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,e653e8a2e136536d683b73afd3e0d00d"
+                ],
+                "wt_fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.WT.sequences.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2026-07-22T11:19:12.010158"
+    }
+}

--- a/modules/msk/generatemutfasta/1.3/tests/nextflow.config
+++ b/modules/msk/generatemutfasta/1.3/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'GENERATEMUTFASTA' {
+        containerOptions = '--network none'
+    }
+}

--- a/modules/msk/generatemutfasta/1.3/tests/nextflow_multi_transcript.config
+++ b/modules/msk/generatemutfasta/1.3/tests/nextflow_multi_transcript.config
@@ -1,0 +1,6 @@
+process {
+    withName: 'GENERATEMUTFASTA' {
+        containerOptions = '--network none'
+        ext.args = '--multi_transcript'
+    }
+}

--- a/modules/msk/generatemutfasta/1.3/tests/tags.yml
+++ b/modules/msk/generatemutfasta/1.3/tests/tags.yml
@@ -1,0 +1,2 @@
+generatemutfasta/1.3:
+  - "modules/msk/generatemutfasta/1.3/**"

--- a/modules/msk/generatemutfasta/1.3/tests/test_generatemutfasta.py
+++ b/modules/msk/generatemutfasta/1.3/tests/test_generatemutfasta.py
@@ -1,0 +1,249 @@
+"""Unit tests for the multi-transcript parsing in generateMutFasta.py.
+
+Covers the adaptation of the parser to Genome Nexus' ``Additional_Transcripts``
+column (``-m extended``): field order
+``Transcript_ID,Hugo_Symbol,HGVSp_Short,HGVSc,Variant_Classification``, the MAF
+``Variant_Classification`` vocabulary, and the fact that the canonical transcript
+is NOT present in that column (so it must be emitted from the main MAF columns).
+
+Run with:  pytest modules/msk/generatemutfasta/tests/test_generatemutfasta.py
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+def _load_module():
+    """Import generateMutFasta.py by path, stubbing the runtime-only mutalyzer dep.
+
+    generateMutFasta imports ``from mutalyzer.normalizer import normalize`` at
+    module load; mutalyzer is heavy and not needed for parsing, so stub it.
+    """
+    mutalyzer = types.ModuleType("mutalyzer")
+    normalizer = types.ModuleType("mutalyzer.normalizer")
+    normalizer.normalize = lambda *a, **k: {}
+    mutalyzer.normalizer = normalizer
+    sys.modules.setdefault("mutalyzer", mutalyzer)
+    sys.modules.setdefault("mutalyzer.normalizer", normalizer)
+
+    script = (
+        Path(__file__).resolve().parents[1]
+        / "resources"
+        / "usr"
+        / "bin"
+        / "generateMutFasta.py"
+    )
+    spec = importlib.util.spec_from_file_location("generatemutfasta", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gmf = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# parse_additional_transcripts
+# ---------------------------------------------------------------------------
+
+
+def test_single_entry_maps_gn_field_order():
+    col = "ENST00000379389,ISG15,p.Ile36=,c.106A>G,Missense_Mutation"
+    assert gmf.parse_additional_transcripts(col) == [
+        ("ISG15", "Missense_Mutation", "p.Ile36=", "ENST00000379389", "", "c.106A>G")
+    ]
+
+
+def test_multiple_entries_semicolon_separated():
+    col = (
+        "ENST1,GENEA,p.A1,c.10A>G,Missense_Mutation;"
+        "ENST2,GENEB,p.B1,c.20del,Frame_Shift_Del"
+    )
+    out = gmf.parse_additional_transcripts(col)
+    assert [e[3] for e in out] == ["ENST1", "ENST2"]
+    assert [e[5] for e in out] == ["c.10A>G", "c.20del"]
+    assert [e[1] for e in out] == ["Missense_Mutation", "Frame_Shift_Del"]
+
+
+def test_refseq_is_always_empty():
+    # Genome Nexus does not emit a per-transcript RefSeq in this column.
+    (effect,) = gmf.parse_additional_transcripts(
+        "ENST1,GENE,p.X,c.1A>G,Missense_Mutation"
+    )
+    assert effect[4] == ""
+
+
+def test_whitespace_is_trimmed():
+    col = " ENST1 , GENE , p.X , c.1A>G , Missense_Mutation "
+    assert gmf.parse_additional_transcripts(col) == [
+        ("GENE", "Missense_Mutation", "p.X", "ENST1", "", "c.1A>G")
+    ]
+
+
+def test_hgvsc_n_prefix_at_expected_position():
+    (effect,) = gmf.parse_additional_transcripts(
+        "ENST1,GENE,p.X,n.100A>G,Splice_Site"
+    )
+    assert effect[5] == "n.100A>G"
+
+
+def test_hgvsc_located_by_prefix_when_position_shifts():
+    # Robustness: if HGVSc is not in slot 3, it is still found by its c./n. prefix.
+    (effect,) = gmf.parse_additional_transcripts(
+        "ENST1,GENE,p.X,Missense_Mutation,c.10A>G"
+    )
+    assert effect[5] == "c.10A>G"
+
+
+def test_missing_hgvsc_is_empty_string():
+    # Four fields, no c./n. anywhere -> hgvsc "" (caller warns and skips).
+    (effect,) = gmf.parse_additional_transcripts("ENST1,GENE,p.X,Silent")
+    assert effect[5] == ""
+
+
+def test_short_record_is_skipped():
+    assert gmf.parse_additional_transcripts("ENST1,GENE,p.X") == []
+
+
+def test_empty_transcript_id_is_skipped():
+    assert gmf.parse_additional_transcripts(",GENE,p.X,c.1A>G,Missense_Mutation") == []
+
+
+def test_trailing_and_blank_entries_tolerated():
+    col = "ENST1,GENE,p.X,c.1A>G,Missense_Mutation;;   ;"
+    out = gmf.parse_additional_transcripts(col)
+    assert len(out) == 1 and out[0][3] == "ENST1"
+
+
+@pytest.mark.parametrize("empty", [None, float("nan"), pd.NA])
+def test_empty_inputs_return_empty_list(empty):
+    assert gmf.parse_additional_transcripts(empty) == []
+
+
+# ---------------------------------------------------------------------------
+# is_neoantigen_capable  (MAF Variant_Classification + legacy VEP terms)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "classification",
+    [
+        "Missense_Mutation",
+        "Nonsense_Mutation",
+        "Nonstop_Mutation",
+        "Frame_Shift_Del",
+        "Frame_Shift_Ins",
+        "In_Frame_Del",
+        "In_Frame_Ins",
+        "Splice_Site",
+        "Translation_Start_Site",
+        # legacy VEP consequence terms still accepted
+        "missense_variant",
+        "frameshift_variant",
+        "inframe_insertion",
+        "splice_acceptor_variant",
+    ],
+)
+def test_capable_classifications(classification):
+    assert gmf.is_neoantigen_capable(classification) is True
+
+
+@pytest.mark.parametrize(
+    "classification",
+    ["Silent", "Intron", "3'UTR", "5'Flank", "RNA", "IGR", "Splice_Region", "", None],
+)
+def test_non_capable_classifications(classification):
+    assert gmf.is_neoantigen_capable(classification) is False
+
+
+# ---------------------------------------------------------------------------
+# process_alt_transcripts  (canonical row must be emitted from main MAF columns)
+# ---------------------------------------------------------------------------
+
+
+class _FakeMut:
+    def __init__(self, row, mt_altered_aa, identifier_key):
+        self.maf_row = row
+        self.mt_altered_aa = mt_altered_aa
+        self.identifier_key = identifier_key
+
+
+def _row(additional_transcripts, transcript_id="ENST_CANON"):
+    return pd.Series(
+        {
+            "Chromosome": "1",
+            "Start_Position": 100,
+            "Reference_Allele": "A",
+            "Tumor_Seq_Allele2": "G",
+            "Transcript_ID": transcript_id,
+            "RefSeq": "NM_1",
+            "HGVSp_Short": "p.Canon",
+            "Variant_Classification": "Missense_Mutation",
+            "Additional_Transcripts": additional_transcripts,
+        }
+    )
+
+
+def test_canonical_row_always_emitted_and_alternates_parsed(monkeypatch):
+    # Silent alt is dropped (not neoantigen-capable); missense alt is built.
+    monkeypatch.setattr(
+        gmf, "normalize_to_windows", lambda tx, hgvsc, pad: ("WTWINDOWAA", "MTWINDOWBB")
+    )
+    mut = _FakeMut(
+        _row(
+            "ENST_ALT1,GENE,p.Alt1,c.10A>G,Missense_Mutation;"
+            "ENST_ALT2,GENE,p.Alt2,c.20A>G,Silent"
+        ),
+        mt_altered_aa="ANNOTATEDWINDOW",
+        identifier_key="mut_key",
+    )
+    map_rows, surrogate_by_seq, surrogate_wt, alt_memo = [], {}, {}, {}
+    gmf.process_alt_transcripts(mut, 8, surrogate_by_seq, surrogate_wt, map_rows, alt_memo)
+
+    assert len(map_rows) == 2
+    canonical = map_rows[0]
+    assert canonical["transcript_id"] == "ENST_CANON"
+    assert canonical["is_annotated"] is True
+    assert canonical["same_as_annotated"] is True
+    assert canonical["refseq"] == "NM_1"
+    assert canonical["hgvsp_short"] == "p.Canon"
+    assert canonical["surrogate_id"] == ""
+
+    alt = map_rows[1]
+    assert alt["transcript_id"] == "ENST_ALT1"
+    assert alt["is_annotated"] is False
+    assert alt["surrogate_id"] != ""  # net-new peptide got a surrogate
+    assert len(surrogate_by_seq) == 1
+
+
+def test_canonical_excluded_defensively_if_present_in_column(monkeypatch):
+    monkeypatch.setattr(
+        gmf, "normalize_to_windows", lambda tx, hgvsc, pad: ("WTWINDOWAA", "MTWINDOWBB")
+    )
+    # Column erroneously includes the canonical transcript; it must not duplicate.
+    mut = _FakeMut(
+        _row("ENST_CANON,GENE,p.Canon,c.5A>G,Missense_Mutation"),
+        mt_altered_aa="ANNOTATEDWINDOW",
+        identifier_key="mut_key",
+    )
+    map_rows = []
+    gmf.process_alt_transcripts(mut, 8, {}, {}, map_rows, {})
+    assert len(map_rows) == 1
+    assert map_rows[0]["transcript_id"] == "ENST_CANON"
+    assert map_rows[0]["is_annotated"] is True
+
+
+def test_empty_column_still_emits_canonical(monkeypatch):
+    monkeypatch.setattr(
+        gmf, "normalize_to_windows", lambda tx, hgvsc, pad: ("WTWINDOWAA", "MTWINDOWBB")
+    )
+    mut = _FakeMut(_row(""), mt_altered_aa="ANNOTATEDWINDOW", identifier_key="mut_key")
+    map_rows = []
+    gmf.process_alt_transcripts(mut, 8, {}, {}, map_rows, {})
+    assert len(map_rows) == 1
+    assert map_rows[0]["is_annotated"] is True

--- a/modules/msk/generatemutfasta/1.3/tests/test_generatemutfasta.py
+++ b/modules/msk/generatemutfasta/1.3/tests/test_generatemutfasta.py
@@ -247,3 +247,60 @@ def test_empty_column_still_emits_canonical(monkeypatch):
     gmf.process_alt_transcripts(mut, 8, {}, {}, map_rows, {})
     assert len(map_rows) == 1
     assert map_rows[0]["is_annotated"] is True
+
+
+# ---------------------------------------------------------------------------
+# Primary-path resilience fixes (folded in from the large-run CHANGE_REPORT)
+# generate_translated_sequences: offline versionless requery + protein guard
+# ---------------------------------------------------------------------------
+
+
+def _primary_row(hgvsc, transcript_id="ENST00000327044"):
+    """A minimal non-synonymous MAF row the mutation() constructor accepts."""
+    return pd.Series(
+        {
+            "Chromosome": "1",
+            "Start_Position": 12345678,
+            "Reference_Allele": "A",
+            "Tumor_Seq_Allele2": "T",
+            "Variant_Classification": "Missense_Mutation",
+            "HGVSp_Short": "p.Gly214Cys",
+            "HGVSc": hgvsc,
+            "Transcript_ID": transcript_id,
+        }
+    )
+
+
+def _capturing_normalize(captured):
+    """A fake mutalyzer.normalize that records its query and returns a valid protein."""
+
+    def _normalize(query):
+        captured["q"] = query
+        return {"protein": {"predicted": "MPQRS", "reference": "MPQKS"}}
+
+    return _normalize
+
+
+def test_full_form_hgvsc_requeries_versionless(monkeypatch):
+    # A full-form HGVSc (contains ':') must be re-queried from the VERSIONLESS
+    # Transcript_ID + the c. part, so mutalyzer resolves from cache with no network.
+    captured = {}
+    monkeypatch.setattr(gmf, "normalize", _capturing_normalize(captured))
+    mut = gmf.mutation(_primary_row("ENST00000327044.6:c.640G>T"))
+    mut.generate_translated_sequences(10)
+    assert captured["q"] == "ENST00000327044:c.640G>T"
+
+
+def test_plain_hgvsc_queried_as_is(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(gmf, "normalize", _capturing_normalize(captured))
+    mut = gmf.mutation(_primary_row("c.640G>T", transcript_id="ENST00000241312"))
+    mut.generate_translated_sequences(10)
+    assert captured["q"] == "ENST00000241312:c.640G>T"
+
+
+def test_missing_protein_consequence_returns_minus1(monkeypatch):
+    # No 'errors' and no usable 'protein' -> skip with -1 instead of KeyError crash.
+    monkeypatch.setattr(gmf, "normalize", lambda q: {"warnings": []})
+    mut = gmf.mutation(_primary_row("c.640G>T"))
+    assert mut.generate_translated_sequences(10) == -1


### PR DESCRIPTION
Adds `generatemutfasta/1.3` with a `--multi_transcript` mode that builds neoantigen peptides for alternate transcripts from Genome Nexus' `Additional_Transcripts` column (`-m extended`).

## Changes
- New optional outputs: `alt_mut_fasta`, `alt_wt_fasta`, `transcript_map` (only when `--multi_transcript` is set).
- `Additional_Transcripts` parser (field order `Transcript_ID,Hugo_Symbol,HGVSp_Short,HGVSc,Variant_Classification`; MAF Variant_Classification vocabulary); canonical transcript emitted from the main MAF columns.
- Primary-path resilience (from a large production run): per-variant try/except skip+count; versionless offline HGVSc requery; guard on missing protein consequence.

## Tests
- pytest 41/41 on the parser + resilience logic.
- nf-test 3/3 with `--profile docker` (real-data + two stub tests incl. `--multi_transcript`).

## Notes
- Container reused: `neoantigen-utils-base:1.4.0` (no new image).
- nf-core lint shows 2 failures + 2 warnings that are **byte-identical on the existing 1.2** module (meta-name/process-name convention; test-tag guidelines; ghcr unreachable) — carried over at 1.2 parity, not introduced here.
- Real-data `--multi_transcript` nf-test data is deferred until Genome Nexus `-m extended` output is released (stub + unit coverage in the meantime).